### PR TITLE
Fix #187: ModuleNotFoundError: No module named 'django' when using SQLAlchemy

### DIFF
--- a/apistar/backends/__init__.py
+++ b/apistar/backends/__init__.py
@@ -1,4 +1,14 @@
-from apistar.backends.django_backend import DjangoBackend
-from apistar.backends.sqlalchemy_backend import SQLAlchemy
+__all__ = []
 
-__all__ = ['SQLAlchemy', 'DjangoBackend']
+try:
+    from apistar.backends.django_backend import DjangoBackend
+    __all__.append('DjangoBackend')
+except ImportError:
+    pass
+
+try:
+    from apistar.backends.sqlalchemy_backend import SQLAlchemy
+    __all__.append('SQLAlchemy')
+except ImportError:
+    pass
+

--- a/apistar/backends/__init__.py
+++ b/apistar/backends/__init__.py
@@ -1,14 +1,13 @@
 __all__ = []
 
 try:
-    from apistar.backends.django_backend import DjangoBackend
+    from apistar.backends.django_backend import DjangoBackend  # noqa
     __all__.append('DjangoBackend')
 except ImportError:
     pass
 
 try:
-    from apistar.backends.sqlalchemy_backend import SQLAlchemy
+    from apistar.backends.sqlalchemy_backend import SQLAlchemy  # noqa
     __all__.append('SQLAlchemy')
 except ImportError:
     pass
-

--- a/apistar/backends/__init__.py
+++ b/apistar/backends/__init__.py
@@ -1,13 +1,12 @@
-__all__ = []
+# flake8: noqa
 
 try:
-    from apistar.backends.django_backend import DjangoBackend  # noqa
-    __all__.append('DjangoBackend')
-except ImportError:
-    pass
+    from apistar.backends.django_backend import DjangoBackend
+except ImportError:  # pragma: no cover
+    DjangoBackend = None  # type: ignore
+
 
 try:
-    from apistar.backends.sqlalchemy_backend import SQLAlchemy  # noqa
-    __all__.append('SQLAlchemy')
-except ImportError:
-    pass
+    from apistar.backends.sqlalchemy_backend import SQLAlchemy
+except ImportError:  # pragma: no cover
+    SQLAlchemy = None  # type: ignore

--- a/apistar/compat.py
+++ b/apistar/compat.py
@@ -10,3 +10,12 @@ try:
     import whitenoise
 except ImportError:  # pragma: no cover
     whitenoise = None
+
+
+# requests >=2.16.0 no longer includes vendored packages and lists urllib3 as a dependency
+try:
+    import urllib3
+except ImportError:  # pragma: no cover
+    # requests installation is <2.16.0
+    import requests
+    urllib3 = requests.packages.urllib3

--- a/apistar/test.py
+++ b/apistar/test.py
@@ -6,6 +6,7 @@ import requests
 from click.testing import CliRunner
 
 from apistar.cli import get_current_app
+from apistar.compat import urllib3
 
 
 class WSGIAdapter(requests.adapters.HTTPAdapter):
@@ -77,7 +78,7 @@ class WSGIAdapter(requests.adapters.HTTPAdapter):
 
         # Build the underlying urllib3.HTTPResponse
         raw_kwargs['body'] = io.BytesIO(b''.join(wsgi_response))
-        raw = requests.packages.urllib3.HTTPResponse(**raw_kwargs)
+        raw = urllib3.HTTPResponse(**raw_kwargs)
 
         # Build the requests.Response
         return self.build_response(request, raw)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ click
 coreapi
 jinja2
 pytest
-requests
+requests>=2.15.1,<2.16
 werkzeug
 
 # Optional

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ click
 coreapi
 jinja2
 pytest
-requests>=2.15.1,<2.16
+requests
 werkzeug
 
 # Optional


### PR DESCRIPTION
Fix for #187.  I'm sure that there is a more elegant way to fix this, but it seems to have gotten the job done.