### PR TITLE
Proposal: Add InjectionCaller to allow nested injection scopes

### DIFF
--- a/apistar/frameworks/asyncio.py
+++ b/apistar/frameworks/asyncio.py
@@ -30,7 +30,8 @@ class ASyncIOApp(CliApp):
         Component(StaticFiles, init=statics.WhiteNoiseStaticFiles),
         Component(Router, init=router.WerkzeugRouter),
         Component(CommandLineClient, init=commandline.ArgParseCommandLineClient),
-        Component(Console, init=console.PrintConsole)
+        Component(Console, init=console.PrintConsole),
+        Component(dependency.InjectionCaller, preload=False)
     ]
 
     HTTP_COMPONENTS = [

--- a/apistar/frameworks/wsgi.py
+++ b/apistar/frameworks/wsgi.py
@@ -37,7 +37,8 @@ class WSGIApp(CliApp):
         Component(StaticFiles, init=statics.WhiteNoiseStaticFiles),
         Component(Router, init=router.WerkzeugRouter),
         Component(CommandLineClient, init=commandline.ArgParseCommandLineClient),
-        Component(Console, init=console.PrintConsole)
+        Component(Console, init=console.PrintConsole),
+        Component(dependency.InjectionCaller, preload=False)
     ]
 
     HTTP_COMPONENTS = [


### PR DESCRIPTION
For better or worse, I often call API functions from elsewhere in my API in a nested fashion (API function A calls API function B). Dependency injection means that the "parent" function is handed any dynamic variables/parameters it needs, but the "child" function must have them supplied explicitly.

A concrete example of this is a GraphQL endpoint. The GQL endpoint is one of a number of HTTP-routed API functions that receive normal dependency injection. But the GraphQL endpoint might expose a number of mutations that themselves call (or are) other API functions. The endpoint, which receives the injected variables, doesn't directly call the mutations (graphene has its own resolver system), nor can it optimistically request all the dependencies that the nested API functions might possibly require. What we want in this case is a way to load the current "injection context" at runtime and reuse it to call other API functions.

The challenge of designing a component that allows this runtime injection is that we want the `state` of the "parent" call to be available to the "child" injection function, and components are typically bound/introspected before that state is known. For example, if the parent parsed an HTTP request header, we want that available to the child.

So here I have one proposal for how to make this work: the `InjectionCaller` component. I'm still getting my bearings with the framework so I'm not sure this is compliant with "the API Star way" and would welcome thoughts.

Here's an example, see the unit test for a more complete one:

```python

def api_function_1(user: AuthenticatedUser):
    """
    This is one of my api functions that uses injection to authenticate a user
    """
    do_something_with_authenticated_user(user)

def api_function_2(call_with_injection: InjectionCaller):
    """
    This is another api function that one way or another needs to call the first function
    but doesn't necessarily know what injected parameters it requires
    """
    # this call will properly parse the authenticated user even though it 
    # wasn't passed to this scope
    call_with_injection(api_fuction_1)
```