### PR TITLE
(feat) JWT Authorization Component

### DIFF
--- a/apistar/components/authorization.py
+++ b/apistar/components/authorization.py
@@ -1,0 +1,38 @@
+import typing
+
+import jwt
+
+from apistar import exceptions, http
+from apistar.types import Settings
+
+Token = typing.NewType('Token', str)
+
+
+class JWT():
+    DEFAULT_SETTINGS = {
+        'JWT_ALGORITHMS': ['HS256'],
+    }
+
+    def __init__(self,
+                 token: Token,
+                 settings: Settings) -> None:
+        authorization_settings = settings.get('AUTHORIZATION', self.DEFAULT_SETTINGS)
+        secret = authorization_settings.get('JWT_SECRET', None)
+        if secret is None:
+            msg = 'The JWT_SECRET setting under AUTHORIZATION settings must be defined.'
+            raise exceptions.ConfigurationError(msg) from None
+        algorithms = authorization_settings.get('JWT_ALGORITHMS', ['HS256'])
+        try:
+            payload = jwt.decode(token, secret, algorithms=algorithms)
+        except Exception:
+            raise exceptions.AuthenticationFailed()
+        self.payload = payload
+
+
+def get_decoded_jwt(authorization: http.Header, settings: Settings):
+    if authorization is None:
+        raise exceptions.NotAuthenticated() from None
+    scheme, token = authorization.split()
+    if scheme.lower() != 'bearer':
+        raise exceptions.AuthenticationFailed() from None
+    return JWT(token=Token(token), settings=settings)

--- a/apistar/components/authorization.py
+++ b/apistar/components/authorization.py
@@ -6,7 +6,6 @@ from apistar import exceptions, http
 from apistar.types import Settings
 
 Token = typing.NewType('Token', str)
-JSON = typing.NewType('JSON', typing.Dict[str, typing.Any])
 Algorithm = typing.NewType('Algorithm', str)
 
 
@@ -49,7 +48,7 @@ class EncodedJWT():
     }
 
     def __init__(self,
-                 payload: JSON,
+                 payload: typing.Dict[str, typing.Any],
                  settings: Settings,
                  algorithm: Algorithm=None) -> None:
         authorization_settings = settings.get('AUTHORIZATION', self.DEFAULT_SETTINGS)

--- a/apistar/components/authorization.py
+++ b/apistar/components/authorization.py
@@ -6,9 +6,11 @@ from apistar import exceptions, http
 from apistar.types import Settings
 
 Token = typing.NewType('Token', str)
+JSON = typing.NewType('JSON', typing.Dict[str, typing.Any])
+Algorithm = typing.NewType('Algorithm', str)
 
 
-class JWT():
+class DecodedJWT():
     DEFAULT_SETTINGS = {
         'JWT_ALGORITHMS': ['HS256'],
     }
@@ -38,4 +40,27 @@ def get_decoded_jwt(authorization: http.Header, settings: Settings):
         raise exceptions.AuthenticationFailed('Could not seperate Authorization scheme and token.') from None
     if scheme.lower() != 'bearer':
         raise exceptions.AuthenticationFailed('Authorization scheme not supported, try Bearer') from None
-    return JWT(token=Token(token), settings=settings)
+    return DecodedJWT(token=Token(token), settings=settings)
+
+
+class EncodedJWT():
+    DEFAULT_SETTINGS = {
+        'JWT_ALGORITHMS': ['HS256'],
+    }
+
+    def __init__(self,
+                 payload: JSON,
+                 settings: Settings,
+                 algorithm: Algorithm=None) -> None:
+        authorization_settings = settings.get('AUTHORIZATION', self.DEFAULT_SETTINGS)
+        secret = authorization_settings.get('JWT_SECRET', None)
+        if secret is None:
+            msg = 'The JWT_SECRET setting under AUTHORIZATION settings must be defined.'
+            raise exceptions.ConfigurationError(msg) from None
+        if algorithm is None:
+            algorithm = authorization_settings.get('JWT_ALGORITHMS', ['HS256'])[0]
+        try:
+            token = jwt.encode(payload, secret, algorithm=algorithm).decode(encoding='UTF-8')
+        except Exception as exc:
+            raise exceptions.ConfigurationError(exc.__class__.__name__) from None
+        self.token = token

--- a/apistar/components/authorization.py
+++ b/apistar/components/authorization.py
@@ -31,8 +31,11 @@ class JWT():
 
 def get_decoded_jwt(authorization: http.Header, settings: Settings):
     if authorization is None:
-        raise exceptions.NotAuthenticated() from None
-    scheme, token = authorization.split()
+        raise exceptions.NotAuthenticated('Authorization header is missing.') from None
+    try:
+        scheme, token = authorization.split()
+    except ValueError:
+        raise exceptions.AuthenticationFailed('Could not seperate Authorization scheme and token.') from None
     if scheme.lower() != 'bearer':
-        raise exceptions.AuthenticationFailed() from None
+        raise exceptions.AuthenticationFailed('Authorization scheme not supported, try Bearer') from None
     return JWT(token=Token(token), settings=settings)

--- a/apistar/exceptions.py
+++ b/apistar/exceptions.py
@@ -76,6 +76,16 @@ class ValidationError(HTTPException):
     default_detail = 'Validation error'
 
 
+class AuthenticationFailed(HTTPException):
+    default_status_code = 401
+    default_detail = 'Incorrect authentication credentials.'
+
+
+class NotAuthenticated(HTTPException):
+    default_status_code = 401
+    default_detail = 'Authentication credentials were not provided.'
+
+
 class NotFound(HTTPException):
     default_status_code = 404
     default_detail = 'Not found'

--- a/apistar/frameworks/asyncio.py
+++ b/apistar/frameworks/asyncio.py
@@ -3,7 +3,8 @@ import typing
 
 from apistar import commands, exceptions, http
 from apistar.components import (
-    commandline, console, dependency, router, schema, statics, templates, umi
+    authorization, commandline, console, dependency, router, schema, statics,
+    templates, umi
 )
 from apistar.core import Command, Component
 from apistar.frameworks.cli import CliApp
@@ -48,7 +49,8 @@ class ASyncIOApp(CliApp):
         Component(http.Body, init=umi.get_body),
         Component(http.Request, init=http.Request),
         Component(http.RequestData, init=umi.get_request_data),
-        Component(FileWrapper, init=umi.get_file_wrapper)
+        Component(FileWrapper, init=umi.get_file_wrapper),
+        Component(authorization.JWT, init=authorization.get_decoded_jwt),
     ]
 
     def __init__(self, **kwargs):

--- a/apistar/frameworks/asyncio.py
+++ b/apistar/frameworks/asyncio.py
@@ -31,7 +31,8 @@ class ASyncIOApp(CliApp):
         Component(StaticFiles, init=statics.WhiteNoiseStaticFiles),
         Component(Router, init=router.WerkzeugRouter),
         Component(CommandLineClient, init=commandline.ArgParseCommandLineClient),
-        Component(Console, init=console.PrintConsole)
+        Component(Console, init=console.PrintConsole),
+        Component(authorization.EncodedJWT, init=authorization.EncodedJWT),
     ]
 
     HTTP_COMPONENTS = [
@@ -50,7 +51,7 @@ class ASyncIOApp(CliApp):
         Component(http.Request, init=http.Request),
         Component(http.RequestData, init=umi.get_request_data),
         Component(FileWrapper, init=umi.get_file_wrapper),
-        Component(authorization.JWT, init=authorization.get_decoded_jwt),
+        Component(authorization.DecodedJWT, init=authorization.get_decoded_jwt),
     ]
 
     def __init__(self, **kwargs):

--- a/apistar/frameworks/wsgi.py
+++ b/apistar/frameworks/wsgi.py
@@ -38,7 +38,8 @@ class WSGIApp(CliApp):
         Component(StaticFiles, init=statics.WhiteNoiseStaticFiles),
         Component(Router, init=router.WerkzeugRouter),
         Component(CommandLineClient, init=commandline.ArgParseCommandLineClient),
-        Component(Console, init=console.PrintConsole)
+        Component(Console, init=console.PrintConsole),
+        Component(authorization.EncodedJWT, init=authorization.EncodedJWT),
     ]
 
     HTTP_COMPONENTS = [
@@ -57,7 +58,7 @@ class WSGIApp(CliApp):
         Component(http.Request, init=http.Request),
         Component(http.RequestData, init=wsgi.get_request_data),
         Component(FileWrapper, init=wsgi.get_file_wrapper),
-        Component(authorization.JWT, init=authorization.get_decoded_jwt),
+        Component(authorization.DecodedJWT, init=authorization.get_decoded_jwt),
     ]
 
     def __init__(self, **kwargs):

--- a/apistar/frameworks/wsgi.py
+++ b/apistar/frameworks/wsgi.py
@@ -5,7 +5,8 @@ from werkzeug.http import HTTP_STATUS_CODES
 
 from apistar import commands, exceptions, http
 from apistar.components import (
-    commandline, console, dependency, router, schema, statics, templates, wsgi
+    authorization, commandline, console, dependency, router, schema, statics,
+    templates, wsgi
 )
 from apistar.core import Command, Component
 from apistar.frameworks.cli import CliApp
@@ -55,7 +56,8 @@ class WSGIApp(CliApp):
         Component(http.Body, init=wsgi.get_body),
         Component(http.Request, init=http.Request),
         Component(http.RequestData, init=wsgi.get_request_data),
-        Component(FileWrapper, init=wsgi.get_file_wrapper)
+        Component(FileWrapper, init=wsgi.get_file_wrapper),
+        Component(authorization.JWT, init=authorization.get_decoded_jwt),
     ]
 
     def __init__(self, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ jinja2
 requests
 werkzeug
 whitenoise
+PyJWT
 
 # Optional
 django

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -1,0 +1,56 @@
+import jwt
+import pytest
+
+from apistar import Route, Settings, TestClient, exceptions, http
+from apistar.components.authorization import JWT, Token
+from apistar.frameworks.asyncio import ASyncIOApp
+from apistar.frameworks.wsgi import WSGIApp
+
+
+def auth_required(request: http.Request, token: JWT):
+    return token.payload
+
+
+@pytest.mark.parametrize('app_class', [WSGIApp, ASyncIOApp])
+def test_jwt(app_class) -> None:
+    routes = [
+        Route('/auth-required-route', 'GET', auth_required),
+    ]
+    settings = {
+        'AUTHORIZATION': {'JWT_SECRET': 'jwt-secret'}
+    }
+
+    app = app_class(routes=routes, settings=settings)
+    client = TestClient(app)
+
+    response = client.get('/auth-required-route')
+    assert response.status_code == 401
+
+    payload = {'user': 1}
+    secret = settings['AUTHORIZATION']['JWT_SECRET']
+    encoded_jwt = jwt.encode(payload, secret)
+
+    response = client.get('auth-required-route', headers={
+        'Authorization': 'Basic',
+    })
+    assert response.status_code == 401
+
+    response = client.get('/auth-required-route', headers={
+        'Authorization': 'Bearer {token}'.format(token=encoded_jwt),
+    })
+    assert response.status_code == 200
+    assert response.json() == payload
+
+    encoded_jwt = jwt.encode(payload, 'wrong-secret')
+    response = client.get('/auth-required-route', headers={
+        'Authorization': 'Bearer {token}'.format(token=encoded_jwt),
+    })
+    assert response.status_code == 401
+
+
+def test_misconfigured_jwt_settings() -> None:
+    settings = Settings({
+        'AUTHORIZATION': {},
+    })
+    with pytest.raises(exceptions.ConfigurationError):
+        JWT(token=Token('abc'), settings=settings)

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -3,7 +3,7 @@ import pytest
 
 from apistar import Route, Settings, TestClient, exceptions, http
 from apistar.components.authorization import (
-    JSON, Algorithm, DecodedJWT, EncodedJWT, Token
+    Algorithm, DecodedJWT, EncodedJWT, Token
 )
 from apistar.frameworks.asyncio import ASyncIOApp
 from apistar.frameworks.wsgi import WSGIApp
@@ -56,7 +56,7 @@ def test_decoded_jwt(app_class) -> None:
 
 
 def test_encoded_jwt() -> None:
-    payload = JSON({'email': 'test@example.com'})
+    payload = {'email': 'test@example.com'}
     token = jwt.encode(payload, 'jwt-secret', algorithm='HS256').decode(encoding='UTF-8')
     settings = Settings({
         'AUTHORIZATION': {'JWT_SECRET': 'jwt-secret'}
@@ -76,7 +76,7 @@ def test_misconfigured_jwt_settings() -> None:
         'AUTHORIZATION': {},
     })
     token = Token('abc')
-    payload = JSON({'some': 'payload'})
+    payload = {'some': 'payload'}
 
     with pytest.raises(exceptions.ConfigurationError):
         DecodedJWT(token=token, settings=settings)

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -28,10 +28,15 @@ def test_jwt(app_class) -> None:
 
     payload = {'user': 1}
     secret = settings['AUTHORIZATION']['JWT_SECRET']
-    encoded_jwt = jwt.encode(payload, secret)
+    encoded_jwt = jwt.encode(payload, secret, algorithm='HS256').decode(encoding='UTF-8')
 
-    response = client.get('auth-required-route', headers={
-        'Authorization': 'Basic',
+    response = client.get('/auth-required-route', headers={
+        'Authorization': 'Bearer',
+    })
+    assert response.status_code == 401
+
+    response = client.get('/auth-required-route', headers={
+        'Authorization': 'Basic username',
     })
     assert response.status_code == 401
 
@@ -41,7 +46,7 @@ def test_jwt(app_class) -> None:
     assert response.status_code == 200
     assert response.json() == payload
 
-    encoded_jwt = jwt.encode(payload, 'wrong-secret')
+    encoded_jwt = jwt.encode(payload, 'wrong-secret').decode(encoding='UTF-8')
     response = client.get('/auth-required-route', headers={
         'Authorization': 'Bearer {token}'.format(token=encoded_jwt),
     })


### PR DESCRIPTION
Hi Tom!

As a follow up from #78 I implemented a JWT Component as part of a new file under the components module called "authorization.py" (to hold common auth components, OAUTH 1.0, OAUTH 2.0, Basic Auth, Digest Auth, AWS Signature, .. sky's the limit).

I tried to follow your current architecture patterns as best I could.

I wasn't sure if I should be including messages about why the request failed when injecting the JWT token / decoding it.

This is just a first pass and doesn't include the other half (creating a new JWT from a payload). Not hard to add but I wanted to make sure I was on the right track. Also wasn't sure how to name it, you have two components, the DecodedJWT and the EncodedJWT, maybe I should change them to that, but, `my_func(request: http.Request, token: authorization.DecodedJWT)` seems worse than just `authorization.JWT`.

The other question I had was about returning the Component, I put the payload inside the Component as `payload`, which requires `token.payload['key']` to get at the data, there is no other information with the JWT (I don't know why we would include the secret or the algorithm used) so I wasn't sure if I should just return a `typing.Dict[str, typing.Any]` "json" dict, but I felt that broke the idea that we are injecting a component called JWT  but is in fact just an anonymous object.

One last thing, I didn't see any use for adding an `Authorization` interface to `interfaces.py`, there were no methods on the JWT class that I would use. But now that I think of it, I could add a `decode` and `encode` method and refactor the JWT component to handle both cases, the only issue being how to call two different init methods on the same component.

edit: Latest commit included DecodedJWT/EncodedJWT Components, one is an http method to be injected and the other is a component to be imported and used. Only hangup I have with the imported component is that mypy will fail unless the person passing the payload argument to EncodedJWT wraps it in the `JSON` type. Not sure if that is what we want or not. My latest commit removes it.