### PR TITLE
Add unit tests for annotated QueryParams and also support for parsing function args from request data

### DIFF
--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -71,6 +71,14 @@ def get_scalar_page_query_param(page: int) -> http.Response:
     return http.Response({'page': page})
 
 
+def get_untyped_page_request_data(page) -> http.Response:
+    return http.Response({'page': page})
+
+
+def get_scalar_page_request_data(page: int) -> http.Response:
+    return http.Response({'page': page})
+
+
 def get_url(url: http.URL) -> http.Response:
     return http.Response({'url': url, 'url.components': url.components})
 
@@ -133,6 +141,8 @@ routes = [
     Route('/page_query_param/', 'GET', get_page_query_param),
     Route('/untyped_page_query_param/', 'GET', get_untyped_page_query_param),
     Route('/scalar_page_query_param/', 'GET', get_scalar_page_query_param),
+    Route('/untyped_page_request_data/', 'POST', get_untyped_page_request_data),
+    Route('/scalar_page_request_data/', 'POST', get_scalar_page_request_data),
     Route('/url/', 'GET', get_url),
     Route('/body/', 'POST', get_body),
     Route('/data/', 'POST', get_data),
@@ -270,6 +280,30 @@ def test_single_scalar_query_param(client):
     assert response.json() == {'page': 123}
     response = client.get(
         'http://example.com/scalar_page_query_param/?page=123&page=456')
+    assert response.json() == {'page': 123}
+
+
+@pytest.mark.parametrize('client', [wsgi_client, async_client])
+def test_single_untyped_request_data(client):
+    """
+    Tests a route where the `page` arg is not annotated
+    """
+    response = client.post('http://example.com/untyped_page_request_data/')
+    assert response.json() == {'page': None}
+    response = client.post(
+        'http://example.com/untyped_page_request_data/', data={'page': 123})
+    assert response.json() == {'page': '123'}
+
+
+@pytest.mark.parametrize('client', [wsgi_client, async_client])
+def test_single_scalar_request_data(client):
+    """
+    Tests a route where the `page` arg is annotated as an int
+    """
+    response = client.post('http://example.com/scalar_page_request_data/')
+    assert response.json() == {'page': None}
+    response = client.post(
+        'http://example.com/scalar_page_request_data/', data={'page': 123})
     assert response.json() == {'page': 123}
 
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -63,6 +63,14 @@ def get_page_query_param(page: http.QueryParam) -> http.Response:
     return http.Response({'page': page})
 
 
+def get_untyped_page_query_param(page) -> http.Response:
+    return http.Response({'page': page})
+
+
+def get_scalar_page_query_param(page: int) -> http.Response:
+    return http.Response({'page': page})
+
+
 def get_url(url: http.URL) -> http.Response:
     return http.Response({'url': url, 'url.components': url.components})
 
@@ -123,6 +131,8 @@ routes = [
     Route('/query_string/', 'GET', get_query_string),
     Route('/query_params/', 'GET', get_query_params),
     Route('/page_query_param/', 'GET', get_page_query_param),
+    Route('/untyped_page_query_param/', 'GET', get_untyped_page_query_param),
+    Route('/scalar_page_query_param/', 'GET', get_scalar_page_query_param),
     Route('/url/', 'GET', get_url),
     Route('/body/', 'POST', get_body),
     Route('/data/', 'POST', get_data),
@@ -221,12 +231,46 @@ def test_query_params(client):
 
 @pytest.mark.parametrize('client', [wsgi_client, async_client])
 def test_single_query_param(client):
+    """
+    Tests a route where the `page` arg is annotated as a QueryParam
+    """
     response = client.get('http://example.com/page_query_param/')
     assert response.json() == {'page': None}
     response = client.get('http://example.com/page_query_param/?page=123')
     assert response.json() == {'page': '123'}
-    response = client.get('http://example.com/page_query_param/?page=123&page=456')
+    response = client.get(
+        'http://example.com/page_query_param/?page=123&page=456')
     assert response.json() == {'page': '123'}
+
+
+@pytest.mark.parametrize('client', [wsgi_client, async_client])
+def test_single_untyped_query_param(client):
+    """
+    Tests a route where the `page` arg is not annotated
+    """
+    response = client.get('http://example.com/untyped_page_query_param/')
+    assert response.json() == {'page': None}
+    response = client.get(
+        'http://example.com/untyped_page_query_param/?page=123')
+    assert response.json() == {'page': '123'}
+    response = client.get(
+        'http://example.com/untyped_page_query_param/?page=123&page=456')
+    assert response.json() == {'page': '123'}
+
+
+@pytest.mark.parametrize('client', [wsgi_client, async_client])
+def test_single_scalar_query_param(client):
+    """
+    Tests a route where the `page` arg is annotated as an int
+    """
+    response = client.get('http://example.com/scalar_page_query_param/')
+    assert response.json() == {'page': None}
+    response = client.get(
+        'http://example.com/scalar_page_query_param/?page=123')
+    assert response.json() == {'page': 123}
+    response = client.get(
+        'http://example.com/scalar_page_query_param/?page=123&page=456')
+    assert response.json() == {'page': 123}
 
 
 @pytest.mark.parametrize('client', [wsgi_client, async_client])


### PR DESCRIPTION
The README says:

> Parameters which do not correspond to a URL path parameter will be treated as
> query parameters for `GET` and `DELETE` requests, or part of the request body
> for `POST`, `PUT`, and `PATCH` requests.

However, there are no unit tests for this behavior, and indeed as far as I can tell it is only currently implemented for query parameters, not the request data dictionary.

This PR does two things:
1. Adds unit tests for automatically parsing scalar-annotated and non-annotated function arguments from query parameters
2. Adds support (and unit tests) for automatically parsing scalar-annotated and non-annotated function arguments from the request data dictionary. In the current code, function arguments are matched first against the URL keywords, then the query parameters. This extends that to check a third place: the request data object.