### PR TITLE
allow changing folder in which app.py resides

### DIFF
--- a/apistar/main.py
+++ b/apistar/main.py
@@ -10,9 +10,10 @@ from apistar.frameworks.cli import CliApp
 from apistar.interfaces import App
 
 
-def load_app(folder) -> App:
+def load_app(filepath) -> App:
+    folder = os.path.dirname(filepath)
     sys.path.insert(0, folder)
-    spec = importlib.util.spec_from_file_location("app", "%s/app.py" % folder)
+    spec = importlib.util.spec_from_file_location("app", filepath)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     app = getattr(module, 'app', None)
@@ -30,9 +31,9 @@ def default_app() -> App:
 
 
 def main() -> None:  # pragma: nocover
-    folder = os.getenv('APISTAR_FOLDER', os.getcwd())
-    if os.path.exists('%s/app.py' % folder):
-        app = load_app(folder)
+    filepath = os.getenv('APISTAR_APP', os.path.join(os.getcwd(), 'app.py'))
+    if os.path.isfile(filepath):
+        app = load_app(filepath)
     else:
         app = default_app()
     app.main()

--- a/apistar/main.py
+++ b/apistar/main.py
@@ -10,9 +10,9 @@ from apistar.frameworks.cli import CliApp
 from apistar.interfaces import App
 
 
-def load_app() -> App:
-    sys.path.insert(0, os.getcwd())
-    spec = importlib.util.spec_from_file_location("app", "app.py")
+def load_app(folder) -> App:
+    sys.path.insert(0, folder)
+    spec = importlib.util.spec_from_file_location("app", "%s/app.py" % folder)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     app = getattr(module, 'app', None)
@@ -30,8 +30,9 @@ def default_app() -> App:
 
 
 def main() -> None:  # pragma: nocover
-    if os.path.exists('app.py'):
-        app = load_app()
+    folder = os.getenv('APISTAR_FOLDER', os.getcwd())
+    if os.path.exists('%s/app.py' % folder):
+        app = load_app(folder)
     else:
         app = default_app()
     app.main()


### PR DESCRIPTION
This PR allows changing the folder in which app.py resides by setting `APISTAR_FOLDER` environment variable. If you wanted to allow changing the filename of `app.py` as well, you could supply the full path to the file and rename the environment variable to `APISTAR_APP`, more akin to flask.

fixes #258