### PR TITLE
Add Optional type class

### DIFF
--- a/apistar/typesystem.py
+++ b/apistar/typesystem.py
@@ -44,6 +44,17 @@ class String(str):
         return value
 
 
+class Optional:
+    """
+    Wraps another type to indicate that it may be None or omitted from
+    an object.
+    """
+    wrapped_type: typing.Any
+
+    def __init__(self, wrapped_type: typing.Any) -> None:
+        self.wrapped_type = wrapped_type
+
+
 class _NumericType(object):
     """
     Base class for both `Number` and `Integer`.
@@ -171,10 +182,13 @@ class Object(dict):
                     # If a key is missing but has a default, then use that.
                     self[key] = child_schema.default
                 else:
-                    exc = TypeSystemError(cls=self.__class__, code='required')
-                    errors[key] = exc.detail
+                    if not isinstance(child_schema, Optional):
+                        exc = TypeSystemError(cls=self.__class__, code='required')
+                        errors[key] = exc.detail
             else:
                 # Coerce value into the given schema type if needed.
+                if isinstance(child_schema, Optional):
+                    child_schema = child_schema.wrapped_type
                 if isinstance(item, child_schema):
                     self[key] = item
                 else:

--- a/apistar/typesystem.py
+++ b/apistar/typesystem.py
@@ -49,8 +49,6 @@ class Optional:
     Wraps another type to indicate that it may be None or omitted from
     an object.
     """
-    wrapped_type: typing.Any
-
     def __init__(self, wrapped_type: typing.Any) -> None:
         self.wrapped_type = wrapped_type
 

--- a/tests/typesystem/test_object.py
+++ b/tests/typesystem/test_object.py
@@ -25,6 +25,13 @@ class HighScore(typesystem.Object):
     }
 
 
+class ObjectWithOptionalValues(typesystem.Object):
+    properties = {
+        'name': typesystem.string(),
+        'some_optional_number': typesystem.Optional(typesystem.number())
+    }
+
+
 def basic_object(score: HighScore):
     return score
 
@@ -97,6 +104,23 @@ class test_object_default():
         'completed': True
     })
     assert value['location'] == {'latitude': 0.0, 'longitude': 0.0}
+
+
+class test_optional_keys():
+    value = ObjectWithOptionalValues({
+        'name': 'steve'
+    })
+    assert value['name'] == 'steve'
+
+
+class test_optional_keys_are_still_validated():
+    with pytest.raises(exceptions.TypeSystemError) as exc:
+        value = ObjectWithOptionalValues({
+            'name': 'steve',
+            'some_optional_number': 'hello'
+        })
+    assert str(exc.value) \
+        == '{\'some_optional_number\': \'Must be a valid number.\'}'
 
 
 class test_raw_instance():

--- a/tests/typesystem/test_object.py
+++ b/tests/typesystem/test_object.py
@@ -119,8 +119,7 @@ class test_optional_keys_are_still_validated():
             'name': 'steve',
             'some_optional_number': 'hello'
         })
-    assert str(exc.value) \
-        == '{\'some_optional_number\': \'Must be a valid number.\'}'
+    assert str(exc.value) == "{'some_optional_number': 'Must be a valid number.'}"
 
 
 class test_raw_instance():


### PR DESCRIPTION
Provides a class `Optional` that can wrap another type so Objects can have poperties that aren't required but that are type checked.
```python
class ObjectWithOptionalValues(typesystem.Object):
    properties = {
        'name': typesystem.string(),
        'some_optional_number': typesystem.Optional(typesystem.number())
    }
```