### PR TITLE
Injection improvements

### DIFF
--- a/apistar/__init__.py
+++ b/apistar/__init__.py
@@ -10,7 +10,7 @@ from apistar.http import Response
 from apistar.test import TestClient
 from apistar.types import Settings
 
-__version__ = '0.2.12'
+__version__ = '0.2.13'
 __all__ = [
     'Command', 'Component', 'Response', 'Route', 'Include', 'Settings',
     'TestClient'

--- a/apistar/components/dependency.py
+++ b/apistar/components/dependency.py
@@ -83,13 +83,15 @@ class DependencyInjector(Injector):
         Returns:
             The return value of the given function.
         """
+        steps = []  # type: typing.List[Step]
         for func in funcs:
             try:
                 # We cache the steps that are required to run a given function.
-                steps = self._steps_cache[func]
+                func_steps = self._steps_cache[func]
             except KeyError:
-                steps = self._create_steps(func)
-                self._steps_cache[func] = steps
+                func_steps = self._create_steps(func)
+                self._steps_cache[func] = func_steps
+            steps += func_steps
 
         # Combine any preconfigured initial state with any explicit per-call state.
         state = {**self._setup_state, **state}
@@ -259,13 +261,15 @@ class AsyncDependencyInjector(DependencyInjector):
         Returns:
             The return value of the given function.
         """
+        steps = []  # type: typing.List[Step]
         for func in funcs:
             try:
                 # We cache the steps that are required to run a given function.
-                steps = self._steps_cache[func]
+                func_steps = self._steps_cache[func]
             except KeyError:
-                steps = self._create_steps(func)
-                self._steps_cache[func] = steps
+                func_steps = self._create_steps(func)
+                self._steps_cache[func] = func_steps
+            steps += func_steps
 
         # Combine any preconfigured initial state with any explicit per-call state.
         state = {**self._setup_state, **state}

--- a/apistar/components/dependency.py
+++ b/apistar/components/dependency.py
@@ -51,8 +51,10 @@ class DependencyInjector(Injector):
         if resolvers is None:
             resolvers = []  # pragma: nocover
 
+        builtin = {ReturnValue: None, Injector: None}
+
         self.components = components
-        self.initial_state = initial_state
+        self.initial_state = {**initial_state, **builtin}
         self.required_state = required_state
         self.resolvers = resolvers
 
@@ -67,21 +69,34 @@ class DependencyInjector(Injector):
         # injection steps for any given function.
         self._steps_cache = {}  # type: typing.Dict[typing.Callable, typing.List[Step]]
 
-    def run(self,
-            funcs: typing.List[typing.Callable],
-            state: typing.Dict[str, typing.Any]={}) -> typing.Any:
+    def run(self, func: typing.Callable) -> typing.Any:
         """
-        Run a function, using dependency inject to resolve any parameters
+        Run a functions, using dependency inject to resolve any parameters
         that it requires.
 
         Args:
             func: The function to run.
+
+        Returns:
+            The return value of the function.
+        """
+        return self.run_all([func], {})
+
+    def run_all(self,
+                funcs: typing.List[typing.Callable],
+                state: typing.Dict[str, typing.Any]={}) -> typing.Any:
+        """
+        Run some functions, using dependency inject to resolve any parameters
+        that they require.
+
+        Args:
+            funcs: The functions to run.
             state: A dictionary of any per-call state that can differ on each
                    run. For example, this might include any base information
                    associated with an incoming HTTP request.
 
         Returns:
-            The return value of the given function.
+            The return value of the final function.
         """
         steps = []  # type: typing.List[Step]
         for func in funcs:
@@ -98,8 +113,9 @@ class DependencyInjector(Injector):
 
         ret = None
         with ExitStack() as stack:
+            state['injector'] = BoundInjector(self, state, stack)
             for step in steps:
-                if step.output_key in state and step.output_key != 'return_value':
+                if step.output_key in state and step.output_key != 'returnvalue':
                     continue
 
                 # Keyword arguments are usually "input_key" references to state
@@ -134,10 +150,7 @@ class DependencyInjector(Injector):
         """
         annotation = param.annotation
 
-        if annotation is ReturnValue:
-            return ('return_value', None)
-
-        elif annotation in self.components:
+        if annotation in self.components:
             # If the type annotation is one of our components, then
             # use the function that is installed for creating that component.
             key = '%s:%d' % (annotation.__name__.lower(), id(annotation))
@@ -223,7 +236,7 @@ class DependencyInjector(Injector):
 
         # Add the step for the function itself.
         if parent_param is None:
-            output_key = 'return_value'
+            output_key = 'returnvalue'
             context_manager = False
         else:
             output_key, _ = self._resolve_parameter(parent_param)
@@ -244,22 +257,104 @@ class DependencyInjector(Injector):
         return steps
 
 
-class AsyncDependencyInjector(DependencyInjector):
-    async def run_async(self,
-                        funcs: typing.List[typing.Callable],
-                        state: typing.Dict[str, typing.Any]={}) -> typing.Any:
+class BoundInjector(Injector):
+    """
+    This injector is available to functions when running inside a dependency
+    injected context. It is automatically provided by DependencyInjector.
+
+    To use it, include the `Injector` component as an annotation in the
+    function. For example:
+
+    def my_function(injector: Injector):
+        injector.run(some_function)
+    """
+    def __init__(self, bound_to, state, stack):
+        self.bound_to = bound_to
+        self.state = state
+        self.stack = stack
+
+    def run(self, func: typing.Callable) -> typing.Any:
         """
         Run a function, using dependency inject to resolve any parameters
         that it requires.
 
         Args:
             func: The function to run.
+
+        Returns:
+            The return value of the given function.
+        """
+        try:
+            # We cache the steps that are required to run a given function.
+            steps = self.bound_to._steps_cache[func]
+        except KeyError:
+            steps = self.bound_to._create_steps(func)
+            self.bound_to._steps_cache[func] = steps
+
+        ret = None
+
+        for step in steps:
+            if step.output_key in self.state and step.output_key != 'returnvalue':
+                continue
+
+            # Keyword arguments are usually "input_key" references to state
+            # that's been generated. In the case of `ParamName` or
+            # `ParamAnnotation` they will be a pre-provided "input_value".
+            kwargs = {
+                argname: self.state[state_key]
+                for (argname, state_key) in step.input_keys.items()
+            }
+            kwargs.update(step.input_values)
+
+            # Run the function, possibly entering it into the context
+            # stack in order to handle context managers.
+            ret = step.func(**kwargs)
+            if hasattr(ret, '__enter__') and hasattr(ret, '__exit__'):
+                ret = self.stack.enter_context(ret)
+            self.state[step.output_key] = ret
+
+        return ret
+
+    def run_all(self,
+                funcs: typing.List[typing.Callable],
+                state: typing.Dict[str, typing.Any]={}) -> typing.Any:
+        raise NotImplementedError(
+            '.run_all() is not available in this context. '
+            'Use .run() instead.'
+        )
+
+
+# asyncio flavoured dependency injector...
+
+class AsyncDependencyInjector(DependencyInjector):
+    async def run_async(self, func: typing.Callable) -> typing.Any:
+        """
+        Run a function, using dependency inject to resolve any parameters
+        that it requires.
+
+        Args:
+            func: The function to run.
+
+        Returns:
+            The return value of the given function.
+        """
+        return await self.run_all_async([func], {})
+
+    async def run_all_async(self,
+                            funcs: typing.List[typing.Callable],
+                            state: typing.Dict[str, typing.Any]={}) -> typing.Any:
+        """
+        Run some functions, using dependency inject to resolve any parameters
+        that they require.
+
+        Args:
+            funcs: The functions to run.
             state: A dictionary of any per-call state that can differ on each
                    run. For example, this might include any base information
                    associated with an incoming HTTP request.
 
         Returns:
-            The return value of the given function.
+            The return value of the final function.
         """
         steps = []  # type: typing.List[Step]
         for func in funcs:
@@ -276,8 +371,9 @@ class AsyncDependencyInjector(DependencyInjector):
 
         ret = None
         with ExitStack() as stack:
+            state['injector'] = AsyncBoundInjector(self, state, stack)
             for step in steps:
-                if step.output_key in state and step.output_key != 'return_value':
+                if step.output_key in state and step.output_key != 'returnvalue':
                     continue
 
                 # Keyword arguments are usually "input_key" references to state
@@ -302,6 +398,79 @@ class AsyncDependencyInjector(DependencyInjector):
 
         return ret
 
+
+class AsyncBoundInjector(BoundInjector):
+    """
+    This injector is available to functions when running inside a dependency
+    injected context. It is automatically provided by AsyncDependencyInjector.
+
+    To use it, include the `Injector` component as an annotation in the
+    function. For example:
+
+    async def my_function(injector: Injector):
+        await injector.run_async(some_function)
+    """
+    def __init__(self, bound_to, state, stack):
+        self.bound_to = bound_to
+        self.state = state
+        self.stack = stack
+
+    async def run_sync(self, func: typing.Callable) -> typing.Any:
+        """
+        Run a function, using dependency inject to resolve any parameters
+        that it requires.
+
+        Args:
+            func: The function to run.
+
+        Returns:
+            The return value of the given function.
+        """
+        try:
+            # We cache the steps that are required to run a given function.
+            steps = self.bound_to._steps_cache[func]
+        except KeyError:
+            steps = self.bound_to._create_steps(func)
+            self.bound_to._steps_cache[func] = steps
+
+        ret = None
+
+        for step in steps:
+            if step.output_key in self.state and step.output_key != 'returnvalue':
+                continue
+
+            # Keyword arguments are usually "input_key" references to state
+            # that's been generated. In the case of `ParamName` or
+            # `ParamAnnotation` they will be a pre-provided "input_value".
+            kwargs = {
+                argname: self.state[state_key]
+                for (argname, state_key) in step.input_keys.items()
+            }
+            kwargs.update(step.input_values)
+
+            # Run the function, possibly entering it into the context
+            # stack in order to handle context managers.
+            if step.is_async:
+                ret = await step.func(**kwargs)
+            else:
+                ret = step.func(**kwargs)
+
+            if hasattr(ret, '__enter__') and hasattr(ret, '__exit__'):
+                ret = self.stack.enter_context(ret)
+            self.state[step.output_key] = ret
+
+        return ret
+
+    async def run_all_async(self,
+                            funcs: typing.List[typing.Callable],
+                            state: typing.Dict[str, typing.Any]={}) -> typing.Any:
+        raise NotImplementedError(
+            '.run_all_async() is not available in this context. '
+            'Use .run_async() instead.'
+        )
+
+
+# The Resolver subclasses below handle mapping annotations to component instances.
 
 class CliResolver(Resolver):
     """

--- a/apistar/frameworks/asyncio.py
+++ b/apistar/frameworks/asyncio.py
@@ -101,11 +101,11 @@ class ASyncIOApp(CliApp):
             handler, kwargs = self.router.lookup(path, method)
             state['kwargs'] = kwargs
             funcs = [handler, self.finalize_response]
-            response = await self.http_injector.run_async(funcs, state=state)
+            response = await self.http_injector.run_all_async(funcs, state=state)
         except Exception as exc:
             state['exc'] = exc  # type: ignore
             funcs = [self.exception_handler, self.finalize_response]
-            response = await self.http_injector.run_async(funcs, state=state)
+            response = await self.http_injector.run_all_async(funcs, state=state)
 
         headers.update(response.headers)
         headers['content-type'] = response.content_type

--- a/apistar/frameworks/asyncio.py
+++ b/apistar/frameworks/asyncio.py
@@ -12,7 +12,7 @@ from apistar.interfaces import (
     CommandLineClient, Console, FileWrapper, Injector, Router, Schema,
     SessionStore, StaticFiles, Templates
 )
-from apistar.types import KeywordArgs, UMIChannels, UMIMessage
+from apistar.types import KeywordArgs, ReturnValue, UMIChannels, UMIMessage
 
 
 class ASyncIOApp(CliApp):
@@ -100,13 +100,12 @@ class ASyncIOApp(CliApp):
         try:
             handler, kwargs = self.router.lookup(path, method)
             state['kwargs'] = kwargs
-            response = await self.http_injector.run_async([handler], state=state)
+            funcs = [handler, self.finalize_response]
+            response = await self.http_injector.run_async(funcs, state=state)
         except Exception as exc:
             state['exc'] = exc  # type: ignore
-            response = await self.http_injector.run_async([self.exception_handler], state=state)
-
-        if getattr(response, 'content_type', None) is None:
-            response = self.finalize_response(response)
+            funcs = [self.exception_handler, self.finalize_response]
+            response = await self.http_injector.run_async(funcs, state=state)
 
         headers.update(response.headers)
         headers['content-type'] = response.content_type
@@ -134,11 +133,13 @@ class ASyncIOApp(CliApp):
 
         raise
 
-    def finalize_response(self, response: http.Response) -> http.Response:
-        if isinstance(response, http.Response):
-            data, status, headers, content_type = response
+    def finalize_response(self, ret: ReturnValue) -> http.Response:
+        if isinstance(ret, http.Response):
+            data, status, headers, content_type = ret
+            if content_type is not None:
+                return ret
         else:
-            data, status, headers, content_type = response, 200, {}, None
+            data, status, headers, content_type = ret, 200, {}, None
 
         if data is None:
             content = b''

--- a/apistar/frameworks/asyncio.py
+++ b/apistar/frameworks/asyncio.py
@@ -100,10 +100,10 @@ class ASyncIOApp(CliApp):
         try:
             handler, kwargs = self.router.lookup(path, method)
             state['kwargs'] = kwargs
-            response = await self.http_injector.run_async(handler, state=state)
+            response = await self.http_injector.run_async([handler], state=state)
         except Exception as exc:
             state['exc'] = exc  # type: ignore
-            response = await self.http_injector.run_async(self.exception_handler, state=state)
+            response = await self.http_injector.run_async([self.exception_handler], state=state)
 
         if getattr(response, 'content_type', None) is None:
             response = self.finalize_response(response)

--- a/apistar/frameworks/cli.py
+++ b/apistar/frameworks/cli.py
@@ -88,7 +88,7 @@ class CliApp(App):
                 continue
 
             try:
-                component = injector.run([func])
+                component = injector.run(func)
             except exceptions.CouldNotResolveDependency:
                 continue
             del components[cls]
@@ -125,7 +125,7 @@ class CliApp(App):
         try:
             handler, kwargs = self.commandline.parse(args)
             state['kwargs'] = kwargs
-            ret = self.cli_injector.run([handler], state=state)
+            ret = self.cli_injector.run_all([handler], state=state)
         except exceptions.CommandLineExit as exc:
             ret = exc.message
         except exceptions.CommandLineError as exc:

--- a/apistar/frameworks/cli.py
+++ b/apistar/frameworks/cli.py
@@ -88,7 +88,7 @@ class CliApp(App):
                 continue
 
             try:
-                component = injector.run(func)
+                component = injector.run([func])
             except exceptions.CouldNotResolveDependency:
                 continue
             del components[cls]
@@ -125,7 +125,7 @@ class CliApp(App):
         try:
             handler, kwargs = self.commandline.parse(args)
             state['kwargs'] = kwargs
-            ret = self.cli_injector.run(handler, state=state)
+            ret = self.cli_injector.run([handler], state=state)
         except exceptions.CommandLineExit as exc:
             ret = exc.message
         except exceptions.CommandLineError as exc:

--- a/apistar/frameworks/wsgi.py
+++ b/apistar/frameworks/wsgi.py
@@ -109,10 +109,10 @@ class WSGIApp(CliApp):
         try:
             handler, kwargs = self.router.lookup(path, method)
             state['kwargs'] = kwargs
-            response = self.http_injector.run(handler, state=state)
+            response = self.http_injector.run([handler], state=state)
         except Exception as exc:
             state['exc'] = exc  # type: ignore
-            response = self.http_injector.run(self.exception_handler, state=state)
+            response = self.http_injector.run([self.exception_handler], state=state)
 
         if getattr(response, 'content_type', None) is None:
             response = self.finalize_response(response)

--- a/apistar/frameworks/wsgi.py
+++ b/apistar/frameworks/wsgi.py
@@ -110,11 +110,11 @@ class WSGIApp(CliApp):
             handler, kwargs = self.router.lookup(path, method)
             state['kwargs'] = kwargs
             funcs = [handler, self.finalize_response]
-            response = self.http_injector.run(funcs, state=state)
+            response = self.http_injector.run_all(funcs, state=state)
         except Exception as exc:
             state['exc'] = exc  # type: ignore
             funcs = [self.exception_handler, self.finalize_response]
-            response = self.http_injector.run(funcs, state=state)
+            response = self.http_injector.run_all(funcs, state=state)
 
         # Get the WSGI response information, given the Response instance.
         try:

--- a/apistar/interfaces.py
+++ b/apistar/interfaces.py
@@ -112,8 +112,13 @@ class Injector(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def run(self,
-            funcs: typing.List[typing.Callable],
-            state: typing.Dict[str, typing.Any]) -> typing.Any:
+            func: typing.Callable) -> typing.Any:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def run_all(self,
+                funcs: typing.List[typing.Callable],
+                state: typing.Dict[str, typing.Any]) -> typing.Any:
         raise NotImplementedError
 
 

--- a/apistar/interfaces.py
+++ b/apistar/interfaces.py
@@ -112,7 +112,7 @@ class Injector(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def run(self,
-            func: typing.Callable,
+            funcs: typing.List[typing.Callable],
             state: typing.Dict[str, typing.Any]) -> typing.Any:
         raise NotImplementedError
 

--- a/apistar/types.py
+++ b/apistar/types.py
@@ -55,6 +55,7 @@ Settings = typing.NewType('Settings', dict)
 
 ParamName = typing.NewType('ParamName', str)
 ParamAnnotation = typing.NewType('ParamAnnotation', type)
+ReturnValue = typing.TypeVar('ReturnValue')
 
 
 # Routing


### PR DESCRIPTION
* Allow a list of functions to be run within the context of the dependency injection.
* Include `finalize_response` as part of dependency injection.
* All handlers to use `Injector` annotation, and run dependency injected functions themselves)

This change work towards being able to add a form of middleware, so we can...

* Have functions that run prior to every request.
* Have functions that run after every request, possibly modifying the return result.