### PR TITLE
Graceful handling of malformed RequestData Issue #120

### DIFF
--- a/apistar/components/umi.py
+++ b/apistar/components/umi.py
@@ -107,11 +107,11 @@ async def get_request_data(headers: http.Headers, message: UMIMessage, channels:
     elif mimetype == 'application/json':
         body = await get_body(message, channels)
         if not body:
-            raise exceptions.EmptyJSON()
+            raise exceptions.BadRequest(detail='Empty JSON')
         try:
             value = json.loads(body.decode('utf-8'))
         except json.JSONDecodeError:
-            raise exceptions.InvalidJSON()
+            raise exceptions.BadRequest(detail='Invalid JSON')
     elif mimetype in ('multipart/form-data', 'application/x-www-form-urlencoded'):
         body = await get_body(message, channels)
         stream = io.BytesIO(body)

--- a/apistar/components/umi.py
+++ b/apistar/components/umi.py
@@ -106,7 +106,12 @@ async def get_request_data(headers: http.Headers, message: UMIMessage, channels:
         value = None
     elif mimetype == 'application/json':
         body = await get_body(message, channels)
-        value = json.loads(body.decode('utf-8'))
+        if not body:
+            raise exceptions.EmptyJSON()
+        try:
+            value = json.loads(body.decode('utf-8'))
+        except json.JSONDecodeError:
+            raise exceptions.InvalidJSON()
     elif mimetype in ('multipart/form-data', 'application/x-www-form-urlencoded'):
         body = await get_body(message, channels)
         stream = io.BytesIO(body)

--- a/apistar/components/wsgi.py
+++ b/apistar/components/wsgi.py
@@ -81,8 +81,13 @@ def get_request_data(environ: WSGIEnviron):
     if mimetype is None:
         value = None
     elif mimetype == 'application/json':
-        body = get_input_stream(environ).read()
-        value = json.loads(body.decode('utf-8'))
+        body = get_body(environ)
+        if not body:
+            raise exceptions.EmptyJSON()
+        try:
+            value = json.loads(body.decode('utf-8'))
+        except json.JSONDecodeError:
+            raise exceptions.InvalidJSON()
     elif mimetype in ('multipart/form-data', 'application/x-www-form-urlencoded'):
         parser = FormDataParser()
         stream, form, files = parser.parse_from_environ(environ)

--- a/apistar/components/wsgi.py
+++ b/apistar/components/wsgi.py
@@ -83,11 +83,11 @@ def get_request_data(environ: WSGIEnviron):
     elif mimetype == 'application/json':
         body = get_body(environ)
         if not body:
-            raise exceptions.EmptyJSON()
+            raise exceptions.BadRequest(detail='Empty JSON')
         try:
             value = json.loads(body.decode('utf-8'))
         except json.JSONDecodeError:
-            raise exceptions.InvalidJSON()
+            raise exceptions.BadRequest(detail='Invalid JSON')
     elif mimetype in ('multipart/form-data', 'application/x-www-form-urlencoded'):
         parser = FormDataParser()
         stream, form, files = parser.parse_from_environ(environ)

--- a/apistar/exceptions.py
+++ b/apistar/exceptions.py
@@ -76,6 +76,11 @@ class ValidationError(HTTPException):
     default_detail = 'Validation error'
 
 
+class BadRequest(HTTPException):
+    default_status_code = 400
+    default_detail = 'Bad request'
+
+
 class NotFound(HTTPException):
     default_status_code = 404
     default_detail = 'Not found'
@@ -89,13 +94,3 @@ class MethodNotAllowed(HTTPException):
 class UnsupportedMediaType(HTTPException):
     default_status_code = 415
     default_detail = 'Unsupported media type'
-
-
-class InvalidJSON(HTTPException):
-    default_status_code = 400
-    default_detail = 'Invalid JSON'
-
-
-class EmptyJSON(HTTPException):
-    default_status_code = 400
-    default_detail = 'Empty JSON'

--- a/apistar/exceptions.py
+++ b/apistar/exceptions.py
@@ -89,3 +89,13 @@ class MethodNotAllowed(HTTPException):
 class UnsupportedMediaType(HTTPException):
     default_status_code = 415
     default_detail = 'Unsupported media type'
+
+
+class InvalidJSON(HTTPException):
+    default_status_code = 400
+    default_detail = 'Invalid JSON'
+
+
+class EmptyJSON(HTTPException):
+    default_status_code = 400
+    default_detail = 'Empty JSON'

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -352,6 +352,27 @@ def test_empty_response(client):
 
 
 @pytest.mark.parametrize('client', [wsgi_client, async_client])
+def test_request_with_invalid_json(client):
+    response = client.post(
+        'http://example.com/data/',
+        headers={'Content-Type': 'application/json'},
+        data='"hello": 123}'
+    )
+    assert response.status_code == 400
+    assert response.json() == {'message': 'Invalid JSON'}
+
+
+@pytest.mark.parametrize('client', [wsgi_client, async_client])
+def test_request_with_empty_json(client):
+    response = client.post(
+        'http://example.com/data/',
+        headers={'Content-Type': 'application/json'}
+    )
+    assert response.status_code == 400
+    assert response.json() == {'message': 'Empty JSON'}
+
+
+@pytest.mark.parametrize('client', [wsgi_client, async_client])
 def test_unknown_status_code(client):
     response = client.get('/unknown_status_code/')
     assert response.status_code == 600


### PR DESCRIPTION
When sending a request with empty JSON data we get JSONDecodeError with `wsgi_client` and AttributeError with `async_client`.

In the first case body is parsed into empty string, `body.decode` works fine but `json.loads(decoded_body)` fails.
In the second case body is parsed into `None` and we end up with `AttributeError` on `body.decode()`.

Likewise, sending malformed data results in unhandled `JSONDecodeError` for both clients.

PR handles those cases to result in 400 response code and appropriate error message. Covered by tests.
https://github.com/encode/apistar/issues/120
