### PR TITLE
Add `RequestStream` component.

### DIFF
--- a/apistar/components/umi.py
+++ b/apistar/components/umi.py
@@ -85,6 +85,10 @@ async def get_body(message: UMIMessage, channels: UMIChannels):
     return body
 
 
+async def get_stream(body: http.Body):
+    return io.BytesIO(body)
+
+
 def _get_content_length(headers: http.Headers) -> typing.Optional[int]:
     content_length = headers.get('Content-Length')
     if content_length is not None:

--- a/apistar/components/wsgi.py
+++ b/apistar/components/wsgi.py
@@ -72,6 +72,10 @@ def get_body(environ: WSGIEnviron):
     return get_input_stream(environ).read()
 
 
+def get_stream(environ: WSGIEnviron):
+    return get_input_stream(environ)
+
+
 def get_request_data(environ: WSGIEnviron):
     if not bool(environ.get('CONTENT_TYPE')):
         mimetype = None

--- a/apistar/frameworks/asyncio.py
+++ b/apistar/frameworks/asyncio.py
@@ -49,6 +49,7 @@ class ASyncIOApp(CliApp):
         Component(http.QueryParam, init=umi.get_queryparam),
         Component(http.Body, init=umi.get_body),
         Component(http.Request, init=http.Request),
+        Component(http.RequestStream, init=umi.get_stream),
         Component(http.RequestData, init=umi.get_request_data),
         Component(FileWrapper, init=umi.get_file_wrapper),
         Component(http.Session, init=sessions.get_session),

--- a/apistar/frameworks/wsgi.py
+++ b/apistar/frameworks/wsgi.py
@@ -56,6 +56,7 @@ class WSGIApp(CliApp):
         Component(http.QueryParam, init=wsgi.get_queryparam),
         Component(http.Body, init=wsgi.get_body),
         Component(http.Request, init=http.Request),
+        Component(http.RequestStream, init=wsgi.get_stream),
         Component(http.RequestData, init=wsgi.get_request_data),
         Component(FileWrapper, init=wsgi.get_file_wrapper),
         Component(http.Session, init=sessions.get_session),

--- a/apistar/http.py
+++ b/apistar/http.py
@@ -1,4 +1,5 @@
 import collections
+import io
 import typing
 from urllib.parse import urlparse
 
@@ -12,6 +13,7 @@ QueryParam = typing.NewType('QueryParam', str)
 Header = typing.NewType('Header', str)
 Body = typing.NewType('Body', bytes)
 
+RequestStream = typing.NewType('RequestStream', io.BufferedIOBase)
 RequestData = typing.TypeVar('RequestData')
 
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -71,6 +71,10 @@ def get_body(body: http.Body) -> http.Response:
     return http.Response({'body': body.decode('utf-8')})
 
 
+def get_stream(stream: http.RequestStream) -> http.Response:
+    return http.Response({'stream': stream.read().decode('utf-8')})
+
+
 def get_data(data: http.RequestData) -> http.Response:
     return http.Response({'data': to_native(data)})
 
@@ -125,6 +129,7 @@ routes = [
     Route('/page_query_param/', 'GET', get_page_query_param),
     Route('/url/', 'GET', get_url),
     Route('/body/', 'POST', get_body),
+    Route('/stream/', 'POST', get_stream),
     Route('/data/', 'POST', get_data),
     Route('/headers/', 'GET', get_headers),
     Route('/headers/', 'POST', get_headers, name='post_headers'),
@@ -262,6 +267,12 @@ def test_url(client):
 def test_body(client):
     response = client.post('http://example.com/body/', data="content")
     assert response.json() == {'body': 'content'}
+
+
+@pytest.mark.parametrize('client', [wsgi_client, async_client])
+def test_stream(client):
+    response = client.post('http://example.com/stream/', data="content")
+    assert response.json() == {'stream': 'content'}
 
 
 @pytest.mark.parametrize('client', [wsgi_client, async_client])


### PR DESCRIPTION
Adds a `RequestStream` component, which we'll want for implementing a `MultiPartParser` class that's identical between both WSGI and asyncio.

The implementation for asyncio reads the entire body into memory. We ought to have some kind of checks around maximum body length etc, but this will have to do for now.