### PR TITLE
Implement general purpose request-parsing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Some of the components you might use most often:
 | `http.QueryParams` | The request query parameters, returned as a dictionary-like object. |
 | `http.QueryParam`  | Lookup a single query parameter, corresponding to the argument name.<br/>Returns a string or `None`. |
 | `http.Body`        | The request body. Returns a bytestring. |
-| `http.RequestData` | The request data, returned as a dictionary-like object. |
+| `http.RequestData` | The parsed request data. Data type will depend on the Content-Type of the request. |
 
 ## Responses
 

--- a/apistar/components/dependency.py
+++ b/apistar/components/dependency.py
@@ -136,6 +136,15 @@ class DependencyInjector(Injector):
 
         return ret
 
+    async def run_async(self,
+                        func: typing.Callable) -> typing.Any:
+        raise NotImplementedError('Cannot use `run_async` when running with WSGI.')
+
+    async def run_all_async(self,
+                            funcs: typing.List[typing.Callable],
+                            state: typing.Dict[str, typing.Any]) -> typing.Any:
+        raise NotImplementedError('Cannot use `run_all_async` when running with WSGI.')
+
     def _resolve_parameter(self, param: inspect.Parameter) -> typing.Tuple[str, typing.Optional[typing.Callable]]:
         """
         Resolve a single function parameter, returning the information needed
@@ -323,6 +332,15 @@ class BoundInjector(Injector):
             'Use .run() instead.'
         )
 
+    async def run_async(self,
+                        func: typing.Callable) -> typing.Any:
+        raise NotImplementedError('Cannot use `run_async` when running with WSGI.')
+
+    async def run_all_async(self,
+                            funcs: typing.List[typing.Callable],
+                            state: typing.Dict[str, typing.Any]) -> typing.Any:
+        raise NotImplementedError('Cannot use `run_all_async` when running with WSGI.')
+
 
 # asyncio flavoured dependency injector...
 
@@ -415,7 +433,7 @@ class AsyncBoundInjector(BoundInjector):
         self.state = state
         self.stack = stack
 
-    async def run_sync(self, func: typing.Callable) -> typing.Any:
+    async def run_async(self, func: typing.Callable) -> typing.Any:
         """
         Run a function, using dependency inject to resolve any parameters
         that it requires.

--- a/apistar/components/umi.py
+++ b/apistar/components/umi.py
@@ -1,13 +1,11 @@
 import io
-import json
 import typing
 
 import werkzeug
-from werkzeug.datastructures import ImmutableMultiDict
-from werkzeug.formparser import FormDataParser
 from werkzeug.http import parse_options_header
 
-from apistar import exceptions, http
+from apistar import exceptions, http, parsers
+from apistar.interfaces import Injector
 from apistar.types import ParamName, UMIChannels, UMIMessage
 
 
@@ -99,34 +97,19 @@ def _get_content_length(headers: http.Headers) -> typing.Optional[int]:
     return None  # pragma: nocover
 
 
-async def get_request_data(headers: http.Headers, message: UMIMessage, channels: UMIChannels):
+async def get_request_data(headers: http.Headers, injector: Injector):
     content_type = headers.get('Content-Type')
-    if content_type:
-        mimetype, options = parse_options_header(content_type)
-    else:
-        mimetype, options = None, {}
+    if not content_type:
+        return None
 
-    if mimetype is None:
-        value = None
-    elif mimetype == 'application/json':
-        body = await get_body(message, channels)
-        if not body:
-            raise exceptions.BadRequest(detail='Empty JSON')
-        try:
-            value = json.loads(body.decode('utf-8'))
-        except json.JSONDecodeError:
-            raise exceptions.BadRequest(detail='Invalid JSON')
-    elif mimetype in ('multipart/form-data', 'application/x-www-form-urlencoded'):
-        body = await get_body(message, channels)
-        stream = io.BytesIO(body)
-        content_length = _get_content_length(headers)
-        parser = FormDataParser()
-        stream, form, files = parser.parse(stream, mimetype, content_length, options)
-        value = ImmutableMultiDict(list(form.items()) + list(files.items()))
-    else:
+    media_type, _ = parse_options_header(content_type)
+
+    if media_type not in parsers.DEFAULT_PARSERS:
         raise exceptions.UnsupportedMediaType()
 
-    return value
+    parser = parsers.DEFAULT_PARSERS[media_type]
+    func = getattr(parser, 'parse')
+    return await injector.run_async(func)
 
 
 def get_file_wrapper():

--- a/apistar/components/wsgi.py
+++ b/apistar/components/wsgi.py
@@ -4,7 +4,7 @@ import werkzeug
 from werkzeug.http import parse_options_header
 from werkzeug.wsgi import get_input_stream
 
-from apistar import exceptions, http, parsers
+from apistar import Settings, exceptions, http, parsers
 from apistar.interfaces import Injector
 from apistar.types import ParamName, WSGIEnviron
 
@@ -74,19 +74,22 @@ def get_stream(environ: WSGIEnviron):
     return get_input_stream(environ)
 
 
-def get_request_data(headers: http.Headers, injector: Injector):
+def get_request_data(headers: http.Headers, injector: Injector, settings: Settings):
     content_type = headers.get('Content-Type')
     if not content_type:
         return None
 
     media_type, _ = parse_options_header(content_type)
+    parser_mapping = {
+        parser.media_type: parser
+        for parser in settings.get('PARSERS', parsers.DEFAULT_PARSERS)
+    }
 
-    if media_type not in parsers.DEFAULT_PARSERS:
+    if media_type not in parser_mapping:
         raise exceptions.UnsupportedMediaType()
 
-    parser = parsers.DEFAULT_PARSERS[media_type]
-    func = getattr(parser, 'parse')
-    return injector.run(func)
+    parser = parser_mapping[media_type]
+    return injector.run(parser.parse)
 
 
 def get_file_wrapper(environ: WSGIEnviron):

--- a/apistar/components/wsgi.py
+++ b/apistar/components/wsgi.py
@@ -1,13 +1,11 @@
-import json
 from wsgiref.util import FileWrapper, request_uri
 
 import werkzeug
-from werkzeug.datastructures import ImmutableMultiDict
-from werkzeug.formparser import FormDataParser
 from werkzeug.http import parse_options_header
 from werkzeug.wsgi import get_input_stream
 
-from apistar import exceptions, http
+from apistar import exceptions, http, parsers
+from apistar.interfaces import Injector
 from apistar.types import ParamName, WSGIEnviron
 
 
@@ -76,30 +74,19 @@ def get_stream(environ: WSGIEnviron):
     return get_input_stream(environ)
 
 
-def get_request_data(environ: WSGIEnviron):
-    if not bool(environ.get('CONTENT_TYPE')):
-        mimetype = None
-    else:
-        mimetype, _ = parse_options_header(environ['CONTENT_TYPE'])
+def get_request_data(headers: http.Headers, injector: Injector):
+    content_type = headers.get('Content-Type')
+    if not content_type:
+        return None
 
-    if mimetype is None:
-        value = None
-    elif mimetype == 'application/json':
-        body = get_body(environ)
-        if not body:
-            raise exceptions.BadRequest(detail='Empty JSON')
-        try:
-            value = json.loads(body.decode('utf-8'))
-        except json.JSONDecodeError:
-            raise exceptions.BadRequest(detail='Invalid JSON')
-    elif mimetype in ('multipart/form-data', 'application/x-www-form-urlencoded'):
-        parser = FormDataParser()
-        stream, form, files = parser.parse_from_environ(environ)
-        value = ImmutableMultiDict(list(form.items()) + list(files.items()))
-    else:
+    media_type, _ = parse_options_header(content_type)
+
+    if media_type not in parsers.DEFAULT_PARSERS:
         raise exceptions.UnsupportedMediaType()
 
-    return value
+    parser = parsers.DEFAULT_PARSERS[media_type]
+    func = getattr(parser, 'parse')
+    return injector.run(func)
 
 
 def get_file_wrapper(environ: WSGIEnviron):

--- a/apistar/interfaces.py
+++ b/apistar/interfaces.py
@@ -121,6 +121,17 @@ class Injector(metaclass=abc.ABCMeta):
                 state: typing.Dict[str, typing.Any]) -> typing.Any:
         raise NotImplementedError
 
+    @abc.abstractmethod
+    async def run_async(self,
+                        func: typing.Callable) -> typing.Any:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    async def run_all_async(self,
+                            funcs: typing.List[typing.Callable],
+                            state: typing.Dict[str, typing.Any]) -> typing.Any:
+        raise NotImplementedError
+
 
 # Console
 

--- a/apistar/parsers.py
+++ b/apistar/parsers.py
@@ -54,8 +54,8 @@ class MultiPartParser():
         return ImmutableMultiDict(list(form.items()) + list(files.items()))
 
 
-DEFAULT_PARSERS = {
-    'application/json': JSONParser(),
-    'application/x-www-form-urlencoded': URLEncodedParser(),
-    'multipart/form-data': MultiPartParser()
-}
+DEFAULT_PARSERS = [
+    JSONParser(),
+    URLEncodedParser(),
+    MultiPartParser()
+]

--- a/apistar/parsers.py
+++ b/apistar/parsers.py
@@ -1,0 +1,61 @@
+import json
+import typing
+
+from werkzeug.datastructures import ImmutableMultiDict
+from werkzeug.formparser import FormDataParser
+from werkzeug.http import parse_options_header
+from werkzeug.urls import url_decode
+
+from apistar import exceptions, http
+
+
+class JSONParser():
+    media_type = 'application/json'
+
+    def parse(self, body: http.Body) -> typing.Any:
+        if not body:
+            raise exceptions.BadRequest(detail='Empty JSON')
+        try:
+            return json.loads(body.decode('utf-8'))
+        except json.JSONDecodeError:
+            raise exceptions.BadRequest(detail='Invalid JSON')
+
+
+class URLEncodedParser():
+    media_type = 'application/x-www-form-urlencoded'
+
+    def parse(self, body: http.Body) -> ImmutableMultiDict:
+        return url_decode(body, cls=ImmutableMultiDict)
+
+
+class MultiPartParser():
+    media_type = 'multipart/form-data'
+
+    def get_content_length(self, headers: http.Headers) -> typing.Optional[int]:
+        content_length = headers.get('Content-Length')
+        if content_length is not None:
+            try:
+                return max(0, int(content_length))
+            except (ValueError, TypeError):
+                pass
+        return None
+
+    def get_mimetype_and_options(self, headers: http.Headers) -> typing.Tuple[str, dict]:
+        content_type = headers.get('Content-Type')
+        if content_type:
+            return parse_options_header(content_type)
+        return '', {}
+
+    def parse(self, headers: http.Headers, stream: http.RequestStream) -> ImmutableMultiDict:
+        mimetype, options = self.get_mimetype_and_options(headers)
+        content_length = self.get_content_length(headers)
+        parser = FormDataParser()
+        stream, form, files = parser.parse(stream, mimetype, content_length, options)
+        return ImmutableMultiDict(list(form.items()) + list(files.items()))
+
+
+DEFAULT_PARSERS = {
+    'application/json': JSONParser(),
+    'application/x-www-form-urlencoded': URLEncodedParser(),
+    'multipart/form-data': MultiPartParser()
+}


### PR DESCRIPTION
This pull request move us away from a single hardcoded request parsing function,
and instead gives use parser classes that each have the responsibility for parsing
a given media type.

We can build on this to allow for configurable request parsing.

Needs documenting, but I'm happy to wait until we *also* have configurable response rendering before doing that.