### PR TITLE
Raise ValidationError if no content type specified on POST

### DIFF
--- a/apistar/components/umi.py
+++ b/apistar/components/umi.py
@@ -101,7 +101,7 @@ def _get_content_length(headers: http.Headers) -> typing.Optional[int]:
 async def get_request_data(headers: http.Headers, injector: Injector, settings: Settings):
     content_type = headers.get('Content-Type')
     if not content_type:
-        return None
+        raise exceptions.ValidationError(detail='No content type specified')
 
     media_type, _ = parse_options_header(content_type)
     parser_mapping = {

--- a/apistar/components/wsgi.py
+++ b/apistar/components/wsgi.py
@@ -78,7 +78,7 @@ def get_stream(environ: WSGIEnviron):
 def get_request_data(headers: http.Headers, injector: Injector, settings: Settings):
     content_type = headers.get('Content-Type')
     if not content_type:
-        return None
+        raise exceptions.ValidationError(detail='No content type specified')
 
     media_type, _ = parse_options_header(content_type)
     parser_mapping = {

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -284,7 +284,8 @@ def test_data(client):
     assert response.json() == {'data': {'hello': 123}}
 
     response = client.post('http://example.com/data/')
-    assert response.json() == {'data': None}
+    assert response.status_code == 400
+    assert response.json() == {'message': 'No content type specified'}
 
     response = client.post('http://example.com/data/', data={'abc': 123})
     assert response.json() == {'data': {'abc': '123'}}


### PR DESCRIPTION
When making POST request to a resource we currently return None, this PR changes the behavior to raise ValidationError instead and provide 400 response with message `No content type specified`.

Covered by test.