### PR TITLE
Allow location override

### DIFF
--- a/apistar/__init__.py
+++ b/apistar/__init__.py
@@ -10,7 +10,7 @@ from apistar.http import Response
 from apistar.test import TestClient
 from apistar.types import Settings
 
-__version__ = '0.3.1'
+__version__ = '0.3.2'
 __all__ = [
     'annotate', 'Command', 'Component', 'Response', 'Route', 'Include',
     'Settings', 'TestClient'

--- a/apistar/interfaces.py
+++ b/apistar/interfaces.py
@@ -116,7 +116,9 @@ class CommandLineClient(metaclass=abc.ABCMeta):
 
 class Resolver(metaclass=abc.ABCMeta):
     @abc.abstractmethod
-    def resolve(self, param: inspect.Parameter) -> typing.Optional[typing.Tuple[str, typing.Callable]]:
+    def resolve(self,
+                param: inspect.Parameter,
+                func: typing.Callable) -> typing.Optional[typing.Tuple[str, typing.Callable]]:
         raise NotImplementedError
 
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -185,7 +185,7 @@ def test_invalid_max_length(client):
     response = client.get('/max_length/abcdef/')
     assert response.status_code == 404
     assert response.json() == {
-        'message': 'Not found'
+        'var': 'Must have no more than 5 characters.'
     }
 
 


### PR DESCRIPTION
Allows handler arguments to have their default location (eg. query parameter, request body, request form field, url path) overridden.

Needs some refinement, but getting this in for now.