### PR TITLE
Treat an empty string boolean type as False

### DIFF
--- a/apistar/typesystem.py
+++ b/apistar/typesystem.py
@@ -121,7 +121,8 @@ class Boolean(object):
                     'true': True,
                     'false': False,
                     '1': True,
-                    '0': False
+                    '0': False,
+                    '': False
                 }[args[0].lower()]
             except KeyError:
                 raise TypeSystemError(cls=cls, code='type') from None

--- a/tests/typesystem/test_boolean.py
+++ b/tests/typesystem/test_boolean.py
@@ -26,6 +26,7 @@ def test_boolean():
     assert typesystem.Boolean('TRUE') is True
     assert typesystem.Boolean('FALSE') is False
     assert typesystem.Boolean('') is False
+    assert typesystem.Boolean() is False
 
 
 def test_valid_boolean():

--- a/tests/typesystem/test_boolean.py
+++ b/tests/typesystem/test_boolean.py
@@ -25,6 +25,7 @@ def test_boolean():
     assert typesystem.Boolean(False) is False
     assert typesystem.Boolean('TRUE') is True
     assert typesystem.Boolean('FALSE') is False
+    assert typesystem.Boolean('') is False
 
 
 def test_valid_boolean():


### PR DESCRIPTION
This makes blank boolean strings handled as a False boolean instead of raising an TypeSystemError saying it's an invalid boolean.

As mentioned in #244.