### PR TITLE
Update Building Websites notes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,11 +538,12 @@ responses, using [Jinja2](http://jinja.pocoo.org/).
 **app.py:**
 
 ```python
-from apistar import Route
+from apistar import Route, annotate
 from apistar.interfaces import Templates
 from apistar.frameworks.wsgi import WSGIApp as App
+from apistar.renderers import HTMLRenderer
 
-
+@annotate(renderers=[HTMLRenderer()])
 def hello(username: str, templates: Templates):
     index = templates.get_template('index.html')
     return index.render(username=username)
@@ -561,9 +562,15 @@ settings = {
 app = App(routes=routes, settings=settings)
 ```
 
-Returning a string response from a view will default to using the `text/html`
-content type. You can override this by returning a `Response`, including an
-explicit `Content-Type` header.
+Returning a string response from a view will default to using the `text/json`
+content type. This means you will need to override this so that your HTML views
+use the `text/html` content type in their responses. There are several ways you can do this,
+including:
+
+1. by annotating your handler function so that it uses the `HTMLRenderer` (as shown above)
+2. by returning a `Response`, including an explicit `Content-Type` header (see [Renderers](#renderers) section for an example)
+3. by using the `BEFORE_REQUEST` and `AFTER_REQUEST` hooks, which fire before and after all requests
+
 
 ## Static Files
 

--- a/README.md
+++ b/README.md
@@ -564,13 +564,11 @@ app = App(routes=routes, settings=settings)
 
 Returning a string response from a view will default to using the `text/json`
 content type. This means you will need to override this so that your HTML views
-use the `text/html` content type in their responses. There are several ways you can do this,
-including:
+use the `text/html` content type in their responses. There are a couple of ways you 
+can do this, including:
 
 1. by annotating your handler function so that it uses the `HTMLRenderer` (as shown above)
 2. by returning a `Response`, including an explicit `Content-Type` header (see [Renderers](#renderers) section for an example)
-3. by using the `BEFORE_REQUEST` and `AFTER_REQUEST` hooks, which fire before and after all requests
-
 
 ## Static Files
 


### PR DESCRIPTION
After suggesting that the README.md needed to be updated because of the changed behaviour w.r.t. content types and HTML responses, I thought it might be helpful to make the changes myself and send a PR.

Here, I've described three options for returning HTML (annotation, explicit Response objects, and AFTER/BEFORE request hooks).