### PR TITLE
Add pool_recycle and pool_size to mysql sqlalchemy

### DIFF
--- a/apistar/backends/sqlalchemy_backend.py
+++ b/apistar/backends/sqlalchemy_backend.py
@@ -22,6 +22,9 @@ class SQLAlchemyBackend(object):
         kwargs = {}
         if url.startswith('postgresql'):  # pragma: nocover
             kwargs['pool_size'] = database_config.get('POOL_SIZE', 5)
+        elif url.startswith('mysql'):  # pragma: nocover
+            kwargs['pool_size'] = database_config.get('POOL_SIZE', 5)
+            kwargs['pool_recycle'] = database_config.get('POOL_RECYCLE', 3600)
 
         self.metadata = metadata
         self.engine = create_engine(url, **kwargs)


### PR DESCRIPTION
Add pool_recycle and pool_size to mysql sqlalchemy backend.

MySQL has a setting `wait_timeout` which will drop connections after being idle for a certain time. This setting is defaults to 8 hours but some distributions default it to 10 minutes. If a connection is dropped by MySQL without SQLAlchemy expecting it it will cause the client to raise an exception with the message (2006, 'MySQL server has gone away'). Setting `pool_recycle` to less than `wait_timeout` is a common way in SQLAlchemy to work around this as it will cause SQLAlchemy to replace any connections older than this value.