### PR TITLE
(bugfix) Check if django settings already configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -1133,7 +1133,13 @@ You then need to add the database config to your settings and the django migrati
 ```python
 from apistar.frameworks.wsgi import WSGIApp as App
 from apistar.backends import django_orm
+import django
 
+# Populate app registry, required before importing django apps or views which import apps
+django.setup()
+
+# imports relying on django's app registry must come after django.setup()
+from myapp.views import my_view
 
 routes = [
    # ...

--- a/apistar/backends/django_orm.py
+++ b/apistar/backends/django_orm.py
@@ -18,8 +18,9 @@ class DjangoORM(object):
             'DATABASES': settings.get('DATABASES', {}),
             'AUTH_USER_MODEL': settings.get('AUTH_USER_MODEL', 'auth.User')
         }
-        django_settings.configure(**config)
-        django.setup()
+        if not django_settings.configured:
+            django_settings.configure(**config)
+            django.setup()
         self.models = {
             model.__name__: model
             for model in apps.get_models()

--- a/apistar/backends/django_orm.py
+++ b/apistar/backends/django_orm.py
@@ -20,7 +20,7 @@ class DjangoORM(object):
         }
         if not django_settings.configured:
             django_settings.configure(**config)
-            django.setup()
+        django.setup()
         self.models = {
             model.__name__: model
             for model in apps.get_models()


### PR DESCRIPTION
Resolves #311 

If a user decides to configure django settings earlier in the `app.py` don't configure again otherwise django will throw `raise RuntimeError('Settings already configured.')`. If the user doesn't include `DATABASES`, `AUTH_USER_MODEL`, or `INSTALLED_APPS` when they configure settings, they won't be configured properly, but if they decide to configure settings early the onus is on them to assign those variables and I am sure the error messages will be helpful enough.

This fix still requires the user to put
```python
import django
django.setup()
```

at the top of their `app.py`, otherwise when you import views from your `views.py` which will inevitably import django models and other stuff you will get a `raise AppRegistryNotReady("Apps aren't loaded yet.")` exception