### PR TITLE
JSON parser encoding error raises a 500

### DIFF
--- a/apistar/parsers.py
+++ b/apistar/parsers.py
@@ -17,7 +17,7 @@ class JSONParser():
             raise exceptions.BadRequest(detail='Empty JSON')
         try:
             return json.loads(body.decode('utf-8'))
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, UnicodeDecodeError):
             raise exceptions.BadRequest(detail='Invalid JSON')
 
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -377,6 +377,17 @@ def test_request_with_invalid_json(client):
 
 
 @pytest.mark.parametrize('client', [wsgi_client, async_client])
+def test_request_with_invalid_encoding(client):
+    response = client.post(
+        'http://example.com/data/',
+        headers={'Content-Type': 'application/json'},
+        data='{"language": "français"}'.encode('iso-8859-1')
+    )
+    assert response.status_code == 400
+    assert response.json() == {'message': 'Invalid JSON'}
+
+
+@pytest.mark.parametrize('client', [wsgi_client, async_client])
 def test_request_with_empty_json(client):
     response = client.post(
         'http://example.com/data/',


### PR DESCRIPTION
If the json content is not properly encoded (apistar assumes that json are in utf-8), raise also a 400 'Invalid JSON'