### PR TITLE
Added a test that demonstrates the 500 error with a wrong 'Accept' header

### DIFF
--- a/apistar/hooks.py
+++ b/apistar/hooks.py
@@ -65,6 +65,7 @@ def render_response(handler: Handler,
         renderer = negotiate_renderer(accept, renderers)
         if renderer is None:
             raise exceptions.NotAcceptable()
+            # return http.Response(status=406)
         content = injector.run(renderer.render, {'response_data': data})
         if isinstance(content, http.Response):
             return content

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -352,6 +352,15 @@ def test_text_response(client):
 
 
 @pytest.mark.parametrize('client', [wsgi_client, async_client])
+def test_text_with_wrong_accept_header(client):
+    response = client.get(
+        '/text/',
+        headers={'Accept': 'application/json'}
+    )
+    assert response.status_code == 406
+
+
+@pytest.mark.parametrize('client', [wsgi_client, async_client])
 def test_data_response(client):
     response = client.get('/data/')
     assert response.json() == {'hello': 'world'}


### PR DESCRIPTION
Just added a test that demonstrates the 500 error when an wrong 'Accept' header is passed