### PR TITLE
Fix incorrect command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1327,7 +1327,7 @@ $ apistar run
 # Serve on port 9001 and use IPv6 only
 $ apistar run --port 9001 --host ::1
 # If you don't like the Werkzeug web debugger, turn it off
-$ apistar run --no-debugger
+$ apistar run --no-debug
 ```
 ## Running in Production
 

--- a/apistar/backends/django_orm.py
+++ b/apistar/backends/django_orm.py
@@ -50,7 +50,7 @@ def get_session(backend: DjangoORM) -> typing.Generator[Session, None, None]:
     atomic.__enter__()
     try:
         yield Session(backend)
-    except:
+    except Exception:
         exc_type, exc_value, exc_traceback = sys.exc_info()
         atomic.__exit__(exc_type, exc_value, exc_traceback)
         raise

--- a/apistar/backends/sqlalchemy_backend.py
+++ b/apistar/backends/sqlalchemy_backend.py
@@ -41,7 +41,7 @@ def get_session(backend: SQLAlchemyBackend) -> typing.Generator[Session, None, N
     try:
         yield session
         session.commit()
-    except:
+    except Exception:
         session.rollback()
         raise
     finally:


### PR DESCRIPTION
The command of turning off debugging in readme is wrong.

The CLI shows command usage option as `--no-debug`, not `--no-debugger`.
```
apistar run --help                                                          
Usage: apistar run [OPTIONS]

  Run the development server.

Options:
  --help          Show this message and exit.
  --host TEXT     The host of the server.
  --port INTEGER  The port of the server.
  --no-debug      Turn the debugger [on|off].
  --no-reloader   Turn the reloader [on|off].
```
And command line options are based on `__doc__` of `run_wsgi` as below. The argument is `debug`, not `debugger`.
```
def run_wsgi(app: App,
             host: str='127.0.0.1',
             port: int=8080,
             debug: bool=True,
             reloader: bool=True) -> None:  # pragma: nocover
    """
    Run the development server.

    Args:
      app: The application instance, which should be a WSGI callable.
      host: The host of the server.
      port: The port of the server.
      debug: Turn the debugger [on|off].
      reloader: Turn the reloader [on|off].
    """
```