### PR TITLE
Fix typo in components/router.py

### DIFF
--- a/apistar/components/router.py
+++ b/apistar/components/router.py
@@ -21,7 +21,7 @@ class WerkzeugRouter(Router):
         for path, method, view, name in flatten_routes(routes):
             if name in views:
                 msg = (
-                    'Route wtih name "%s" exists more than once. Use an '
+                    'Route with name "%s" exists more than once. Use an '
                     'explicit name="..." on the Route to avoid a conflict.'
                 ) % name
                 raise exceptions.ConfigurationError(msg)


### PR DESCRIPTION
Fix typo `wtih` -> `with` as pointed out in https://github.com/encode/apistar/issues/340