### PR TITLE
Add support for nullable fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ Validates string data. A subclass of `str`.
 * `format` - An identifier indicating a complex datatype with a string representation. For example `"date"`, to represent an ISO 8601 formatted date string.
 * `trim_whitespace` - `True ` if leading and trailing whitespace should be stripped from the data. Defaults to `True`.
 * `description` - A description for online documentation
+* `nullable` - `True` if it should be possible to set the value to `None`
 
 ### Number
 
@@ -430,6 +431,7 @@ Validates numeric data. A subclass of `float`.
 * `exclusive_minimum` - `True` for an exclusive minimum limit. Defaults to `False`.
 * `multiple_of` - A float that the data must be strictly divisible by, in order to be valid.
 * `description` - A description for online documentation
+* `nullable` - `True` if it should be possible to set the value to `None`
 
 ### Integer
 
@@ -442,6 +444,7 @@ Validates integer data. A subclass of `int`.
 * `exclusive_minimum` - `True` for an exclusive minimum limit. Defaults to `False`.
 * `multiple_of` - An integer that the data must be strictly divisible by, in order to be valid.
 * `description` - A description for online documentation
+* `nullable` - `True` if it should be possible to set the value to `None`
 
 ### Boolean
 

--- a/apistar/typesystem.py
+++ b/apistar/typesystem.py
@@ -13,14 +13,22 @@ class String(str):
         'min_length': 'Must have at least {min_length} characters.',
         'pattern': 'Must match the pattern /{pattern}/.',
         'input_type': 'Must be a valid {input_type}.',
+        'null': 'Must not be null.',
     }
     max_length = None  # type: int
     min_length = None  # type: int
     pattern = None  # type: str
     input_type = None  # type: str
     trim_whitespace = True
+    nullable = False
 
     def __new__(cls, *args, **kwargs):
+        if args and args[0] is None:
+            if cls.nullable:
+                return None
+            else:
+                raise TypeSystemError(cls=cls, code='null')
+
         value = super().__new__(cls, *args, **kwargs)
 
         if cls.trim_whitespace:
@@ -63,8 +71,12 @@ class _NumericType:
     exclusive_minimum = False
     exclusive_maximum = False
     multiple_of = None  # type: typing.Union[float, int]
+    nullable = False
 
     def __new__(cls, *args, **kwargs):
+        if cls.nullable and args and args[0] is None:
+            return None
+
         try:
             value = cls.native_type.__new__(cls, *args, **kwargs)
         except (TypeError, ValueError):

--- a/tests/typesystem/test_integer.py
+++ b/tests/typesystem/test_integer.py
@@ -1,4 +1,6 @@
-from apistar import Route, TestClient, typesystem
+import pytest
+
+from apistar import Route, TestClient, exceptions, typesystem
 from apistar.frameworks.wsgi import WSGIApp as App
 
 
@@ -9,6 +11,10 @@ class MinMaxInteger(typesystem.Integer):
 
 class MultipleInteger(typesystem.Integer):
     multiple_of = 10
+
+
+class NullableInteger(typesystem.Integer):
+    nullable = True
 
 
 def get_min_max(value: MinMaxInteger):
@@ -64,3 +70,13 @@ def test_invalid_multiple():
     response = client.get('/multiple/?value=55')
     assert response.status_code == 400
     assert response.json() == {'value': 'Must be a multiple of 10.'}
+
+
+def test_valid_nullable():
+    assert NullableInteger(None) is None
+
+
+def test_invalid_not_nullable():
+    with pytest.raises(exceptions.TypeSystemError) as exc:
+        MinMaxInteger(None)
+    assert str(exc.value) == 'Must be a valid number.'

--- a/tests/typesystem/test_number.py
+++ b/tests/typesystem/test_number.py
@@ -1,4 +1,6 @@
-from apistar import Route, TestClient, typesystem
+import pytest
+
+from apistar import Route, TestClient, exceptions, typesystem
 from apistar.frameworks.wsgi import WSGIApp as App
 
 
@@ -11,6 +13,10 @@ class MinMaxNumber(typesystem.Number):
 
 class MultipleNumber(typesystem.Number):
     multiple_of = 0.1
+
+
+class NullableNumber(typesystem.Number):
+    nullable = True
 
 
 def get_min_max(value: MinMaxNumber):
@@ -72,3 +78,13 @@ def test_invalid_multiple():
     response = client.get('/multiple/?value=1.23')
     assert response.status_code == 400
     assert response.json() == {'value': 'Must be a multiple of 0.1.'}
+
+
+def test_valid_nullable():
+    assert NullableNumber(None) is None
+
+
+def test_invalid_not_nullable():
+    with pytest.raises(exceptions.TypeSystemError) as exc:
+        MinMaxNumber(None)
+    assert str(exc.value) == 'Must be a valid number.'

--- a/tests/typesystem/test_string.py
+++ b/tests/typesystem/test_string.py
@@ -1,4 +1,6 @@
-from apistar import Route, TestClient, typesystem
+import pytest
+
+from apistar import Route, TestClient, exceptions, typesystem
 from apistar.frameworks.wsgi import WSGIApp as App
 
 
@@ -13,6 +15,10 @@ class NotBlank(typesystem.String):
 
 class ValidPattern(typesystem.String):
     pattern = '^[A-Za-z0-9_]+$'
+
+
+class Nullable(typesystem.String):
+    nullable = True
 
 
 def validate_length(value: MinMaxLength):
@@ -83,3 +89,13 @@ def test_invalid_pattern():
     response = client.get('/pattern/?value=')
     assert response.status_code == 400
     assert response.json() == {'value': 'Must match the pattern /^[A-Za-z0-9_]+$/.'}
+
+
+def test_valid_nullable():
+    assert Nullable(None) is None
+
+
+def test_invalid_not_nullable():
+    with pytest.raises(exceptions.TypeSystemError) as exc:
+        NotBlank(None)
+    assert str(exc.value) == 'Must not be null.'


### PR DESCRIPTION
This commit adds support for `None` as a value for string and numeric fields, including unit tests. Ref #70