### PR TITLE
Add shell command to Django backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1206,6 +1206,14 @@ def list_customers(session: Session):
     ]
 ```
 
+**Accessing the shell**
+
+To interact with the Django shell, use the `shell` command included in `django_orm.commands`:
+
+```bash
+$ apistar shell
+```
+
 ---
 
 # Components

--- a/apistar/backends/django_orm.py
+++ b/apistar/backends/django_orm.py
@@ -70,6 +70,10 @@ def migrate():
     call_command('migrate')
 
 
+def shell():
+    call_command('shell')
+
+
 def showmigrations():  # pragma: nocover
     call_command('showmigrations')
 
@@ -83,5 +87,6 @@ commands = [
     Command('flush', flush),
     Command('makemigrations', makemigrations),
     Command('migrate', migrate),
+    Command('shell', shell),
     Command('showmigrations', showmigrations)
 ]

--- a/tests/backends/test_djangoorm.py
+++ b/tests/backends/test_djangoorm.py
@@ -76,3 +76,9 @@ def test_list_create(setup_tables):
     response = client.get('/kittens/')
     assert response.status_code == 200
     assert response.json() == [created_kitten]
+
+
+def test_shell_command_present():
+    commands = django_orm.commands
+    shell_commands = filter(lambda c: c.name is 'shell', commands)
+    assert len(list(shell_commands)) is 1

--- a/tests/backends/test_djangoorm.py
+++ b/tests/backends/test_djangoorm.py
@@ -79,6 +79,5 @@ def test_list_create(setup_tables):
 
 
 def test_shell_command_present():
-    commands = django_orm.commands
-    shell_commands = filter(lambda c: c.name is 'shell', commands)
-    assert len(list(shell_commands)) is 1
+    command_names = [c.name for c in django_orm.commands]
+    assert 'shell' in command_names


### PR DESCRIPTION
This PR adds a `shell` command to `apistar.backends.django_orm.commands`
to make it easier to access a Django-ready shell.

I had a hard time writing a test that asserted that a Python shell got
launched when the command was executed, but I can take another crack at
adding such a test if you'd like.