### PR TITLE
Process default values with type

### DIFF
--- a/apistar/typesystem.py
+++ b/apistar/typesystem.py
@@ -176,7 +176,7 @@ class Object(dict):
             except KeyError:
                 if hasattr(child_schema, 'default'):
                     # If a key is missing but has a default, then use that.
-                    self[key] = child_schema.default
+                    self[key] = child_schema(child_schema.default)
                 elif key in self.required:
                     exc = TypeSystemError(cls=self.__class__, code='required')
                     errors[key] = exc.detail


### PR DESCRIPTION
# Example of usage
```python
import typing
from apistar import typesystem, environment


class Database(typing.NamedTuple):
    HOST: str
    PORT: int
    USER: str
    PASSWORD: str
    NAME: str

class DSN(typesystem.String):
    def __new__(cls, *args, **kwargs):
        value = super().__new__(cls, *args, **kwargs)
        # Parse DSN value
        return Database(host, port, user, password, name)
```

Next I define Environment

```python
class Env(environment.Environment):
    properties = {
        'DATABASE': typesystem.newtype(DSN, default='postgresql://scott:tiger@localhost/test')
    }

env = Env()
print(env['DATABASE'])
```
Current result if no environment variable passed is:
`postgresql://scott:tiger@localhost/test`

Expected by me:
`Database(HOST='localhost', PORT=5432, USER='scott', PASSWORD='tiger', NAME='test')`

Of course, I can use next definition
```python
typesystem.newtype(DSN, default=DSN('postgresql://scott:tiger@localhost/test'))
```

OR

```python
typesystem.newtype(DSN, default=Database('localhost', 5432, 'scott', 'tiger', 'test'))
```

But I think, that my variant is better. What do you think?