### PR TITLE
Handle 406 not acceptable response

### DIFF
--- a/apistar/hooks.py
+++ b/apistar/hooks.py
@@ -62,7 +62,10 @@ def render_response(handler: Handler,
     else:
         default_renderers = settings.get('RENDERERS', DEFAULT_RENDERERS)
         renderers = getattr(handler, 'renderers', default_renderers)
-        renderer = negotiate_renderer(accept, renderers)
+        if status == 406:
+            renderer = negotiate_renderer(accept, renderers, force=True)
+        else:
+            renderer = negotiate_renderer(accept, renderers, force=False)
         if renderer is None:
             raise exceptions.NotAcceptable()
         content = injector.run(renderer.render, {'response_data': data})

--- a/apistar/renderers.py
+++ b/apistar/renderers.py
@@ -42,8 +42,9 @@ class HTMLRenderer(Renderer):
 
 
 def negotiate_renderer(accept: typing.Optional[str],
-                       renderers: typing.List[Renderer]) -> typing.Optional[Renderer]:
-    if accept is None:
+                       renderers: typing.List[Renderer],
+                       force: bool=False) -> typing.Optional[Renderer]:
+    if accept is None or force:
         return renderers[0]
 
     for media_type, quality in parse_accept_header(accept):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -338,6 +338,15 @@ def test_accept_header(client):
 
 
 @pytest.mark.parametrize('client', [wsgi_client, async_client])
+def test_unacceptable_header(client):
+    response = client.get('/data/', headers={'accept': 'a/b'})
+    assert response.status_code == 406
+    assert response.headers['Content-Type'] == 'application/json'
+    assert response.json() == {'message':
+        'Could not satisfy the request Accept header'}
+
+
+@pytest.mark.parametrize('client', [wsgi_client, async_client])
 def test_binary_response(client):
     response = client.get('/binary/')
     assert response.text == '<html><h1>Hello, world</h1></html>'


### PR DESCRIPTION
Fix #334. Return correct response when Accept header cannot be satisfied.