### PR TITLE
Fixing issue 332: No .get() method when Python 3.5.2 is used

### DIFF
--- a/apistar/http.py
+++ b/apistar/http.py
@@ -2,6 +2,7 @@ import collections
 import io
 import typing
 from urllib.parse import urlparse
+from apistar.types import MappingGetMixin
 
 Method = typing.NewType('Method', str)
 Scheme = typing.NewType('Scheme', str)
@@ -37,7 +38,7 @@ StringPairsMapping = typing.Mapping[str, str]
 StringPairs = typing.Union[StringPairsSequence, StringPairsMapping]
 
 
-class QueryParams(typing.Mapping[str, str]):
+class QueryParams(typing.Mapping[str, str], MappingGetMixin):
     """
     An immutable multidict.
     """
@@ -88,7 +89,7 @@ class QueryParams(typing.Mapping[str, str]):
         return 'QueryParams(%s)' % repr(self._list)
 
 
-class Headers(typing.Mapping[str, str]):
+class Headers(typing.Mapping[str, str], MappingGetMixin):
     """
     An immutable, case-insensitive multidict.
     """

--- a/apistar/types.py
+++ b/apistar/types.py
@@ -67,3 +67,14 @@ ReturnValue = typing.TypeVar('ReturnValue')
 
 class PathWildcard(typesystem.String):
     pass
+
+
+# Mixin to add .get() method to mapping-derived classes
+# (necessary for Python 3.5.2)
+
+class MappingGetMixin(object):
+    def get(self, key, default=None):
+        if key in self:
+            return self[key]
+        else:
+            return default


### PR DESCRIPTION
When Python 3.5.2 (or lower?) is used, `apistar.http.Headers` and `apistar.http.QueryParams` make many of tests fail because there is no `.get()` method (https://github.com/encode/apistar/issues/332). In newer versions of Python `.get()` method comes with `typing.Mapping` which these classes subclass.

This PR creates a mixin class which adds a `get` method if it doesn't exist yet. However, if it does (e.g. in Python 3.6), the standard one (from `typing.Mapping`) is used.