### PR TITLE
Add required argument APP to the run subcommand

### DIFF
--- a/apistar/__init__.py
+++ b/apistar/__init__.py
@@ -10,7 +10,6 @@ from apistar import exceptions
 from apistar.core import Command, Component, Include, Route, annotate
 from apistar.frameworks.cli import CliApp
 from apistar.http import Response
-from apistar.interfaces import App
 from apistar.test import TestClient
 from apistar.types import Settings
 from apistar.utils import import_app

--- a/apistar/__init__.py
+++ b/apistar/__init__.py
@@ -5,9 +5,6 @@
  /_  _\    / ___ \|  __/| |   ___) | || (_| | |      /_  _\
    \/     /_/   \_\_|  |___| |____/ \__\__,_|_|        \/
 """
-import importlib.util
-import os
-import sys
 
 from apistar import exceptions
 from apistar.core import Command, Component, Include, Route, annotate
@@ -16,6 +13,7 @@ from apistar.http import Response
 from apistar.interfaces import App
 from apistar.test import TestClient
 from apistar.types import Settings
+from apistar.utils import import_app
 
 __version__ = '0.3.9'
 __all__ = [
@@ -23,46 +21,20 @@ __all__ = [
     'Include', 'Settings', 'TestClient'
 ]
 
-_current_app = None
-
 
 def main() -> None:
-    if os.path.exists('app.py'):
-        app = get_current_app()
-    else:
+    try:
+        app = import_app('app:app')
+    except exceptions.ConfigurationError:
         app = CliApp()
     app.main()
 
 
-def get_current_app(use_cache=True) -> App:
-    global _current_app
-
-    if _current_app is not None and use_cache:
-        return _current_app
-
-    sys.path.insert(0, os.getcwd())
-    spec = importlib.util.spec_from_file_location("app", "app.py")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    app = getattr(module, 'app', None)
-    if app is None:
-        msg = "The 'app.py' module did not contain an 'app' variable."
-        raise exceptions.ConfigurationError(msg)
-    if not isinstance(app, App):
-        msg = "The 'app' variable in 'app.py' is not an App instance."
-        raise exceptions.ConfigurationError(msg)
-
-    if use_cache:
-        _current_app = app
-
-    return app
-
-
 def reverse_url(identifier: str, **values) -> str:
-    app = get_current_app()
+    app = import_app('app:app')
     return app.reverse_url(identifier, **values)
 
 
 def render_template(template_name: str, **context) -> str:
-    app = get_current_app()
+    app = import_app('app:app')
     return app.render_template(template_name, **context)

--- a/apistar/commands/__init__.py
+++ b/apistar/commands/__init__.py
@@ -1,6 +1,6 @@
 from apistar.commands.new import new
-from apistar.commands.run import run_asyncio, run_wsgi
+from apistar.commands.run import run, run_asyncio, run_wsgi
 from apistar.commands.schema import schema
 from apistar.commands.test import test
 
-__all__ = ['new', 'run_asyncio', 'run_wsgi', 'schema', 'test']
+__all__ = ['new', 'run', 'run_asyncio', 'run_wsgi', 'schema', 'test']

--- a/apistar/commands/run.py
+++ b/apistar/commands/run.py
@@ -4,10 +4,10 @@ from apistar.utils import import_app
 
 
 def run(app: AppLoader=import_app,
-             host: str='127.0.0.1',
-             port: int=8080,
-             debug: bool=True,
-             reloader: bool=True) -> None:  # pragma: nocover
+        host: str='127.0.0.1',
+        port: int=8080,
+        debug: bool=True,
+        reloader: bool=True) -> None:  # pragma: nocover
     """
         Run the development server.
 

--- a/apistar/commands/run.py
+++ b/apistar/commands/run.py
@@ -1,20 +1,48 @@
-from apistar.interfaces import App
+from apistar.exceptions import ConfigurationError
+from apistar.types import AppLoader
+from apistar.utils import import_app
 
 
-def run_wsgi(app: App,
+def run(app: AppLoader=import_app,
              host: str='127.0.0.1',
              port: int=8080,
              debug: bool=True,
              reloader: bool=True) -> None:  # pragma: nocover
     """
-    Run the development server.
+        Run the development server.
 
-    Args:
-      app: The application instance, which should be a WSGI callable.
-      host: The host of the server.
-      port: The port of the server.
-      debug: Turn the debugger [on|off].
-      reloader: Turn the reloader [on|off].
+        Args:
+          app: The application instance.
+          host: The host of the server.
+          port: The port of the server.
+          debug: Turn the debugger [on|off].
+          reloader: Turn the reloader [on|off]. Ignored when for ASyncIO apps.
+    """
+    from apistar.frameworks.wsgi import WSGIApp
+    from apistar.frameworks.asyncio import ASyncIOApp
+
+    if isinstance(app, WSGIApp):
+        run_wsgi(app, host, port, debug, reloader)
+    elif isinstance(app, ASyncIOApp):
+        run_asyncio(app, host, port, debug)
+    else:
+        raise ConfigurationError("Unsupported application type %r" % app)
+
+
+def run_wsgi(app: AppLoader=import_app,
+             host: str='127.0.0.1',
+             port: int=8080,
+             debug: bool=True,
+             reloader: bool=True) -> None:  # pragma: nocover
+    """
+        Run the WSGI development server.
+
+        Args:
+          app: The application instance, which should be a WSGI callable.
+          host: The host of the server.
+          port: The port of the server.
+          debug: Turn the debugger [on|off].
+          reloader: Turn the reloader [on|off].
     """
     import werkzeug
 
@@ -26,18 +54,18 @@ def run_wsgi(app: App,
     werkzeug.run_simple(host, port, app, **options)
 
 
-def run_asyncio(app: App,
+def run_asyncio(app: AppLoader=import_app,
                 host: str='127.0.0.1',
                 port: int=8080,
-                debug: bool=True):  # pragma: nocover
+                debug: bool=True) -> None:  # pragma: nocover
     """
-    Run the development server.
+        Run the ASyncIO development server.
 
-    Args:
-      app: The application instance, which should be a UMI callable.
-      host: The host of the server.
-      port: The port of the server.
-      debug: Turn the debugger [on|off].
+        Args:
+          app: The application instance, which should be a UMI callable.
+          host: The host of the server.
+          port: The port of the server.
+          debug: Turn the debugger [on|off].
     """
     import uvicorn
 

--- a/apistar/components/commandline.py
+++ b/apistar/components/commandline.py
@@ -5,7 +5,7 @@ import typing
 
 from apistar import exceptions
 from apistar.interfaces import CommandLineClient
-from apistar.types import CommandConfig, HandlerLookup
+from apistar.types import CommandConfig, HandlerLookup, AppLoader
 
 
 def main(usage):
@@ -33,10 +33,19 @@ class ArgParseCommandLineClient(CommandLineClient):
                 if annotation is inspect.Parameter.empty:
                     annotation = str
 
-                if issubclass(annotation, (str, int, float, bool)):
+                supported_types = (str, int, float, bool, typing.Callable)
+                if issubclass(annotation, supported_types):
                     name = param_name.replace('_', '-')
                     default = param.default
-                    if default is inspect.Parameter.empty:
+
+                    if annotation in [AppLoader]:
+                        command.add_positional(
+                            param_name,
+                            metavar=name.upper(),
+                            help=description,
+                            type=default
+                        )
+                    elif default is inspect.Parameter.empty:
                         command.add_positional(
                             param_name,
                             metavar=name.upper(),

--- a/apistar/frameworks/cli.py
+++ b/apistar/frameworks/cli.py
@@ -13,6 +13,9 @@ class CliApp(App):
 
     BUILTIN_COMMANDS = [
         Command('new', commands.new),
+        Command('run', commands.run),
+        Command('schema', commands.schema),
+        Command('test', commands.test)
     ]
 
     BUILTIN_COMPONENTS = [
@@ -41,7 +44,7 @@ class CliApp(App):
             RouteConfig: routes,
             CommandConfig: commands,
             Settings: settings,
-            App: self,
+            # App: self,
         }
 
         self.components, self.preloaded_state = self.preload_components(

--- a/apistar/types.py
+++ b/apistar/types.py
@@ -54,6 +54,7 @@ Settings = typing.NewType('Settings', dict)
 # that a component is being injected into. These allow for behavior such
 # as components that make a lookup based on the parameter name used.
 
+AppLoader = typing.Callable[[str], typing.Any]
 ParamName = typing.NewType('ParamName', str)
 ParamAnnotation = typing.NewType('ParamAnnotation', type)
 ReturnValue = typing.TypeVar('ReturnValue')

--- a/apistar/utils.py
+++ b/apistar/utils.py
@@ -1,0 +1,38 @@
+import os
+import sys
+
+from importlib import import_module
+
+from apistar import exceptions, interfaces
+
+
+def import_object(spec: str):
+    parts = spec.split(":", 1)
+    module, obj = parts[0], parts[1]
+
+    try:
+        sys.path.insert(0, '.')
+        if module in sys.modules:
+            del sys.modules[module]
+        mod = import_module(module)
+        del sys.path[0]
+    except (ModuleNotFoundError, ValueError, ImportError) as exc:
+        if module.endswith(".py") and os.path.exists(module):
+            msg_template = "Failed to find application, did you mean '%s:%s'?"
+            msg = msg_template % (module.rsplit(".", 1)[0], obj)
+            raise exceptions.ConfigurationError(msg)
+        else:
+            raise exceptions.ConfigurationError() from exc
+    try:
+        return eval(obj, vars(mod))
+    except NameError:
+        msg = "Failed to find application object %r in %r" % (obj, module)
+        raise exceptions.ConfigurationError(msg)
+
+
+def import_app(spec: str):
+    obj = import_object(spec)
+    if not isinstance(obj, interfaces.App):
+        msg = "Application object must implement apistar.App"
+        raise exceptions.ConfigurationError(msg)
+    return obj

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -38,7 +38,7 @@ def app_loader_args(a: AppLoader=import_app):
     Args:
       a: A parameter.
     """
-    return 'a=%s' % a
+    return 'a=%s' % type(a)
 
 
 commands = [
@@ -174,7 +174,7 @@ def test_default_args():
 
 def test_app_loader_args():
     ret = app.main(['app_loader_args', 'tests.test_commandline:wsgi_app'], standalone_mode=False)
-    assert True
+    assert ret == "a=<class 'apistar.frameworks.wsgi.WSGIApp'>"
 
 
 def test_unknown_command():

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -2,6 +2,9 @@ import pytest
 
 from apistar import Command, exceptions
 from apistar.frameworks.cli import CliApp
+from apistar.frameworks.wsgi import WSGIApp
+from apistar.types import AppLoader
+from apistar.commands.run import import_app
 
 
 def no_args():
@@ -28,12 +31,27 @@ def default_args(a=True, b=False, c: int=None, d: float=None):
     return 'a=%s, b=%s, c=%s, d=%s' % (a, b, c, d)
 
 
+def app_loader_args(a: AppLoader=import_app):
+    """
+    Returns the values for a.
+
+    Args:
+      a: A parameter.
+    """
+    return 'a=%s' % a
+
+
 commands = [
     Command('no_args', no_args),
     Command('required_args', required_args),
-    Command('default_args', default_args)
+    Command('default_args', default_args),
+    Command('app_loader_args', app_loader_args)
 ]
 app = CliApp(commands=commands)
+
+
+wsgi_app = WSGIApp()
+wsgi_app.__call__ = lambda *args, **kwargs: print('ok.')
 
 
 def _get_help_lines(content):
@@ -53,7 +71,6 @@ def test_main():
 
 def test_help():
     ret = app.main(['--help'], standalone_mode=False)
-    print(ret)
     assert _get_help_lines(ret) == [
         "Usage: <progname> COMMAND [OPTIONS] [ARGS]...",
         "",
@@ -63,10 +80,14 @@ def test_help():
         "  --help  Show this message and exit.",
         "",
         "Commands:",
-        "  new            Create a new project in TARGET_DIR.",
-        "  no_args        ",
-        "  required_args  Returns the values for a and b.",
-        "  default_args   Returns the values for a, b, c, and d, which have default values."
+        "  new              Create a new project in TARGET_DIR.",
+        "  run              Run the development server.",
+        "  schema           Generate an API schema.",
+        "  test             Run the test suite.",
+        "  no_args          ",
+        "  required_args    Returns the values for a and b.",
+        "  default_args     Returns the values for a, b, c, and d, which have default values.",
+        "  app_loader_args  Returns the values for a.",
     ]
 
 
@@ -111,6 +132,19 @@ def test_default_args_subcommand_help():
     ]
 
 
+def test_app_loader_subcommand_help():
+    ret = app.main(['app_loader_args', '--help'], standalone_mode=False)
+    lines = _get_help_lines(ret)
+    assert lines == [
+        "Usage: <progname> app_loader_args A [OPTIONS]",
+        "",
+        "  Returns the values for a.",
+        "",
+        "Options:",
+        "  --help  Show this message and exit.",
+    ]
+
+
 def test_noargs():
     ret = app.main(['no_args'], standalone_mode=False)
     assert ret == 'abc'
@@ -136,6 +170,11 @@ def test_default_args():
 
     ret = app.main(['default_args', '--d', '123'], standalone_mode=False)
     assert ret == 'a=True, b=False, c=None, d=123.0'
+
+
+def test_app_loader_args():
+    ret = app.main(['app_loader_args', 'tests.test_commandline:wsgi_app'], standalone_mode=False)
+    assert True
 
 
 def test_unknown_command():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,10 @@
 import os
 import tempfile
 
+
 import pytest
 
-from apistar import exceptions, get_current_app
+from apistar import exceptions, import_app
 from apistar.frameworks.cli import CliApp
 from apistar.interfaces import App
 
@@ -13,7 +14,7 @@ def test_get_current_app():
         os.chdir(tempdir)
         app = CliApp()
         app.main(['new', '.'], standalone_mode=False)
-        loaded = get_current_app(use_cache=False)
+        loaded = import_app('app:app')
         assert isinstance(loaded, App)
 
 
@@ -23,7 +24,7 @@ def test_get_missing_app():
         with open('app.py', 'w') as app_file:
             app_file.write('')
         with pytest.raises(exceptions.ConfigurationError):
-            get_current_app(use_cache=False)
+            import_app('app:app')
 
 
 def test_get_invalid_app():
@@ -32,4 +33,4 @@ def test_get_invalid_app():
         with open('app.py', 'w') as app_file:
             app_file.write('app = 123\n')
         with pytest.raises(exceptions.ConfigurationError):
-            get_current_app(use_cache=False)
+            import_app('app:app')


### PR DESCRIPTION
This PR is an effort to fix  #350, is somewhat related to the PR #259.

To be able to run the application from any directory is valuable and possible in many other frameworks. For instance gunicorn:

    gunicorn webapp.somemodule:app \
        --worker-class=meinheld.gmeinheld.MeinheldWorker. 

I addressed this issue in a very similar manner, now `apistar run` requires a positional APP argument which make possible to run `App` from anywhere:

    apistar run myapp.gateway.app:app

I'm concerned with the `import_app()` because the module unloading was mainly untested.

I really liked of the command line approach using MyPy and dependency injection, even that it turned very difficult for me to understand.

Congratulations for this nice framework. We are attempting to run it on production.

Maybe this PR can fix this annoying issue.