### PR TITLE
Fix Must be an object Exception when the value is None #325

### DIFF
--- a/apistar/typesystem.py
+++ b/apistar/typesystem.py
@@ -186,7 +186,8 @@ class Object(dict):
                     self[key] = item
                 else:
                     try:
-                        self[key] = child_schema(item)
+                        if item is not None:
+                            self[key] = child_schema(item)
                     except TypeSystemError as exc:
                         errors[key] = exc.detail
 


### PR DESCRIPTION
I've tried to make a minimal example to reproduce an error that happened to me when I was using sqlalchemy queries with a nullable relationship. I realized that this error occurs because the entity object has the key attribute, but the value is None. 

```python
def list_foo():
    list = [{
        'id': 1,
        'name': 'foo_with_bar',
        'bar': {
            'id': 30
        }
    },
    {
        'id': 2,
        'name': 'foo_with_none_bar',
        'bar': None # <---- Like this
    }]

    return [FooType(foo) for foo in list]


class BarType(typesystem.Object):
    properties = {
        'id': typesystem.integer()
    }


class FooType(typesystem.Object):
    properties = {
        'id': typesystem.integer(),
        'name': typesystem.string(),
        'bar': BarType,
    }

routes = [
    Route('/', 'GET', list_foo),
]

```

It raises the above exception:

```
  File "/.env/lib/python3.6/site-packages/apistar/typesystem.py", line 196, in __init__
    raise TypeSystemError(errors)
apistar.exceptions.TypeSystemError: {'bar': 'Must be an object.'}

```

I suggest to insert condition right before the code above to verify if the item is not None. https://github.com/encode/apistar/blob/7d7dc3a11983915882687ca8607b9eca2ae5ff57/apistar/typesystem.py#L189

```
if item is not None:
    self[key] = child_schema(item)
```

Travis checking should work after #345 is merged.