### PR TITLE
Fixed array field for Api Documentation

### DIFF
--- a/apistar/components/schema.py
+++ b/apistar/components/schema.py
@@ -134,6 +134,8 @@ def get_param_schema(annotated_type: typing.Type) -> coreschema.schemas.Schema:
         return coreschema.Integer(**schema_kwargs)
     elif issubclass(annotated_type, float):
         return coreschema.Number(**schema_kwargs)
+    elif issubclass(annotated_type, list):
+        return coreschema.Array(**schema_kwargs)
     elif issubclass(annotated_type, typesystem.Enum):
         enum = typing.cast(typing.Type[typesystem.Enum], annotated_type)
         return coreschema.Enum(enum=enum.enum, **schema_kwargs)


### PR DESCRIPTION
When I try to use `typesystem.Array` in `typesystem.Object`, it didn't work on API documentation.

Issue: https://github.com/encode/apistar/issues/391

<img width="509" alt="screen shot 2018-02-17 at 01 31 22" src="https://user-images.githubusercontent.com/1684999/36332251-897f2624-1382-11e8-96c7-991bf16367d0.png">

