### PR TITLE
Handle unexpected arguments in server['message']

### DIFF
--- a/apistar/components/umi.py
+++ b/apistar/components/umi.py
@@ -16,7 +16,7 @@ def get_method(message: UMIMessage):
 
 def get_url(message: UMIMessage):
     scheme = message['scheme']
-    host, port = message['server']
+    host, port = message['server'][0:2]
     path = message['path']
 
     if (scheme == 'http' and port != 80) or (scheme == 'https' and port != 443):


### PR DESCRIPTION
On some servers (ubuntu 16.04), if you run apistar with localhost, then message['server'] will return 4 values instead of 2.

Example: 
```
$ host localhost
localhost has address 127.0.0.1
localhost has IPv6 address ::1
apistar run --host localhost --port 5010
```

This can be worked around by specifying 127.0.0.1 instead of localhost, or editing /etc/hosts, but a more reliable solution is to limit the returned range within the code.

Traceback/debuging
```
ValueError: too many values to unpack (expected 2)
File "/usr/share/python/certainmesh/lib/python3.6/site-packages/apistar/components/umi.py", line 19, in get_url
Open an interactive python shell in this framehost, port = message['server']

>>> print(message.get('server'))
('::1', 5010, 0, 0)
>>> host, port = message['server'][0:2]
>>> host
'::1'
>>> port
5010
```