### PR TITLE
Added SqlAlchemy "pool_recycle" option support in settings

### DIFF
--- a/apistar/backends/sqlalchemy_backend.py
+++ b/apistar/backends/sqlalchemy_backend.py
@@ -22,7 +22,9 @@ class SQLAlchemyBackend(object):
         kwargs = {}
         if url.startswith('postgresql'):  # pragma: nocover
             kwargs['pool_size'] = database_config.get('POOL_SIZE', 5)
-
+        if "POOL_RECYCLE" in database_config:
+            kwargs['pool_recycle'] = database_config['POOL_RECYCLE']
+        
         self.metadata = metadata
         self.engine = create_engine(url, **kwargs)
         self.Session = sessionmaker(bind=self.engine)


### PR DESCRIPTION
To deal with disconnected MySQL/MariaDB connection after a long time inactivity that cause this error:

> MySQL server has gone away (BrokenPipeError(32, 'Broken pipe'))

Settings sample:
```
settings = {
    "AUTHENTICATION": [BasicAuthentication()],
    "DATABASE": {
        "URL": "mysql+pymysql://%s:%s@%s/%s" % (
            config.params['db']['username'],
            config.params['db']['password'],
            config.params['db']['host'],
            config.params['db']['dbname']
        ),
        "METADATA": Base.metadata,
        "POOL_RECYCLE": 3600
    }
}
```