### PR TITLE
Email Validator

### DIFF
--- a/apistar/validators.py
+++ b/apistar/validators.py
@@ -632,6 +632,7 @@ class Uniqueness():
 
         return element
 
+
 class Email(String):
     def __init__(self, **kwargs):
         super().__init__(pattern=EMAIL_RE, **kwargs)

--- a/apistar/validators.py
+++ b/apistar/validators.py
@@ -14,6 +14,12 @@ FORMATS = {
     'datetime': formats.DateTimeFormat()
 }
 
+EMAIL_RE = re.compile(
+    r"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z]+)*"  # dot-atom
+    r'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-011\013\014\016-\177])*"'  # quoted-string
+    r')@(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+[A-Z]{2,6}\.?$',
+    re.IGNORECASE)  # domain
+
 
 class Validator():
     errors = {}
@@ -106,7 +112,10 @@ class String(Validator):
 
         assert max_length is None or isinstance(max_length, int)
         assert min_length is None or isinstance(min_length, int)
-        assert pattern is None or isinstance(pattern, str)
+        assert pattern is None or isinstance(pattern, str) or isinstance(
+            pattern, re._pattern_type)
+        # assert pattern is None or isinstance(pattern, str) or isinstance(
+        #     pattern, type(re.compile(''))
         assert enum is None or isinstance(enum, list) and all([isinstance(i, str) for i in enum])
         assert format is None or isinstance(format, str)
 
@@ -622,3 +631,7 @@ class Uniqueness():
             ]))
 
         return element
+
+class Email(String):
+    def __init__(self, **kwargs):
+        super().__init__(pattern=EMAIL_RE, **kwargs)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,10 @@
+from apistar import validators
+from apistar.exceptions import ValidationError
+import pytest 
+
+def test_email():
+    a = validators.Email()
+    assert a.validate('coucou@hello.fr') == "coucou@hello.fr"
+    a = validators.Email()
+    with pytest.raises(ValidationError):
+        a.validate("hello")

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,6 +1,8 @@
+import pytest
+
 from apistar import validators
 from apistar.exceptions import ValidationError
-import pytest 
+
 
 def test_email():
     a = validators.Email()


### PR DESCRIPTION
re.compile type is tricky, you get it at runtime or via the private object. 

I added a file test_validator because I didn't know where to put it.

Maybe A new file called "addon_validator.py" separated from "base validators" could be a good thing.

the regex is stolen at django