### PR TITLE
Required field

### DIFF
--- a/apistar/types.py
+++ b/apistar/types.py
@@ -17,7 +17,7 @@ class TypeMetaclass(ABCMeta):
                 )
                 raise ConfigurationError(msg % (key, name))
             if key == "required" and isinstance(value, Sequence):
-                required=value
+                required = value
 
             elif isinstance(value, validators.Validator):
                 attrs.pop(key)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -180,3 +180,33 @@ def test_as_jsonschema():
             "created"
         ]
     }
+
+from apistar.exceptions import ValidationError
+
+class Bla(types.Type):
+    a = validators.String()
+    b = validators.String()
+    c = validators.String(default="c")
+
+    required = ['a']
+
+def test_required():
+    with pytest.raises(ValidationError) as e:
+        Bla()
+        print(e)
+    assert str(e.value) == "{'a': 'This field is required.'}"
+
+    bla = Bla(a = "a")
+    assert bla.a == "a" and bla.c =="c"
+
+class Bla2(types.Type):
+    a = validators.String()
+    b = validators.String()
+    c = validators.String(default="c")
+
+def test_required_default():
+    with pytest.raises(ValidationError) as e:
+        Bla2()
+    assert str(e.value) == "{'a': 'This field is required.', 'b': 'This field is required.'}"
+    bla = Bla(a = "a", b="b")
+    assert bla.a == "a" and bla.c =="c" and bla.b == "b"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,6 +4,8 @@ import pytest
 
 from apistar import exceptions, types, validators
 from apistar.utils import encode_jsonschema
+from apistar.exceptions import ValidationError
+
 
 utc = datetime.timezone.utc
 
@@ -181,7 +183,6 @@ def test_as_jsonschema():
         ]
     }
 
-from apistar.exceptions import ValidationError
 
 class Bla(types.Type):
     a = validators.String()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,9 +4,8 @@ import json
 import pytest
 
 from apistar import exceptions, types, validators
-from apistar.utils import encode_jsonschema
 from apistar.exceptions import ValidationError
-
+from apistar.utils import encode_jsonschema
 
 utc = datetime.timezone.utc
 
@@ -192,24 +191,27 @@ class Bla(types.Type):
 
     required = ['a']
 
+
 def test_required():
     with pytest.raises(ValidationError) as e:
         Bla()
         print(e)
     assert str(e.value) == "{'a': 'This field is required.'}"
 
-    bla = Bla(a = "a")
-    assert bla.a == "a" and bla.c =="c"
+    bla = Bla(a="a")
+    assert bla.a == "a" and bla.c == "c"
+
 
 class Bla2(types.Type):
     a = validators.String()
     b = validators.String()
     c = validators.String(default="c")
 
+
 def test_required_default():
     with pytest.raises(ValidationError) as exc:
         Bla2()
-    res  = str(exc.value).replace("'", '"')
+    res = str(exc.value).replace("'", '"')
     assert json.loads(res) == {'a': 'This field is required.', 'b': 'This field is required.'}
-    bla = Bla(a = "a", b="b")
-    assert bla.a == "a" and bla.c =="c" and bla.b == "b"
+    bla = Bla(a="a", b="b")
+    assert bla.a == "a" and bla.c == "c" and bla.b == "b"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 
 import pytest
 
@@ -208,6 +209,7 @@ class Bla2(types.Type):
 def test_required_default():
     with pytest.raises(ValidationError) as exc:
         Bla2()
-    assert str(exc.value) == "{'a': 'This field is required.', 'b': 'This field is required.'}"
+    res  = str(exc.value).replace("'", '"')
+    assert json.loads(res) == {'a': 'This field is required.', 'b': 'This field is required.'}
     bla = Bla(a = "a", b="b")
     assert bla.a == "a" and bla.c =="c" and bla.b == "b"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -206,8 +206,8 @@ class Bla2(types.Type):
     c = validators.String(default="c")
 
 def test_required_default():
-    with pytest.raises(ValidationError) as e:
+    with pytest.raises(ValidationError) as exc:
         Bla2()
-    assert str(e.value) == "{'a': 'This field is required.', 'b': 'This field is required.'}"
+    assert str(exc.value) == "{'a': 'This field is required.', 'b': 'This field is required.'}"
     bla = Bla(a = "a", b="b")
     assert bla.a == "a" and bla.c =="c" and bla.b == "b"


### PR DESCRIPTION
Background  : a field required was removed in this new version. Now we have to specify "default" fo each non required field. This make the Types declaration very verbose. For example If you have a "create" schema, you only want a few required field but for most they aren't required so we have to write many things to achieve this.
The default parameter is not the same thing for all kind of validators. for String you can specifiy ''. For integer it's None and we have to add allow_null.
There is also a problem with the "enum" parameter. you can't specify a default (None or '') if it's not in the enum list or tuple.

For all those things a separated "required field" is much easier to use. Therefore it's more explicit (zen of python blabla...) and it's a bit faster (ok only 0,000000000001s) because you don't loop over properties.

In my PR I propose to keep both possibilities (via default or via field) even I think the default parameter way is not a good one.

Last thing : If there is a way to inherite a Type class (I really like to knno if it's possible and how), it will be much more easier with a separated "required" field.