### PR TITLE
Tests for ASGI interface

### DIFF
--- a/apistar/server/app.py
+++ b/apistar/server/app.py
@@ -17,6 +17,8 @@ from apistar.server.wsgi import WSGI_COMPONENTS, WSGIEnviron, WSGIStartResponse
 
 
 class App():
+    interface = 'wsgi'
+
     def __init__(self,
                  routes,
                  template_dir=None,
@@ -154,6 +156,8 @@ class App():
 
 
 class ASyncApp(App):
+    interface = 'asgi'
+
     def init_injector(self, components=None):
         components = components if components else []
         components = list(ASGI_COMPONENTS + VALIDATION_COMPONENTS) + components

--- a/apistar/server/asgi.py
+++ b/apistar/server/asgi.py
@@ -62,7 +62,7 @@ class PathComponent(Component):
 class QueryStringComponent(Component):
     def resolve(self,
                 scope: ASGIScope) -> http.QueryString:
-        return http.QueryString(scope['query_string'])
+        return http.QueryString(scope['query_string'].decode())
 
 
 class QueryParamsComponent(Component):
@@ -88,6 +88,8 @@ class HeadersComponent(Component):
         return http.Headers([
             (key.decode(), value.decode())
             for key, value in scope['headers']
+        ] + [
+            ('host', scope['server'][0]),
         ])
 
 
@@ -102,9 +104,10 @@ class HeaderComponent(Component):
 
 
 class BodyComponent(Component):
-    def resolve(self,
-                receive: ASGIReceive) -> http.Body:
-        return http.Body(b'...')
+    async def resolve(self,
+                      receive: ASGIReceive) -> http.Body:
+        message = await receive()
+        return http.Body(message['body'])
 
 
 class RequestComponent(Component):


### PR DESCRIPTION
Added ASGI adapter for test client and updated http tests to use parametrized fixture, now all tests using `client` fixture will be called twice with WSGI and ASGI apps.

Tests helped to find these issues:

- QueryStringComponent didn't decoded bytes to str.

- HeadersComponent didn't include 'host' header.

- BodyComponent didn't returned body at all. Current body retrieval does not support partial bodies, probably this should be added later.