### PR TITLE
Fix PyPy on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache: pip
 python:
     - "3.5"
     - "3.6"
+    - "pypy3.5"
 
 install:
     - pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,6 @@ whitenoise
 codecov
 flake8
 isort
+mypy ; implementation_name != 'pypy'
 pytest
 pytest-cov

--- a/scripts/lint
+++ b/scripts/lint
@@ -9,4 +9,6 @@ set -x
 
 ${PREFIX}flake8 apistar tests
 ${PREFIX}isort apistar tests --recursive --check-only
-#${PREFIX}mypy apistar tests --ignore-missing-imports
+if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then
+    ${PREFIX}mypy apistar tests --ignore-missing-imports
+fi


### PR DESCRIPTION
Since `mypy`'s dependencies don't play well with PyPy, ensure they're not installed (and `mypy` itself is skipped) when running in that environment.