### PR TITLE
Only require mypy if not running under PyPy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,6 @@ whitenoise
 codecov
 flake8
 isort
+# mypy ; implementation_name != 'pypy'
 pytest
 pytest-cov

--- a/scripts/lint
+++ b/scripts/lint
@@ -9,4 +9,6 @@ set -x
 
 ${PREFIX}flake8 apistar tests
 ${PREFIX}isort apistar tests --recursive --check-only
-#${PREFIX}mypy apistar tests --ignore-missing-imports
+# if ! expr "$TRAVIS_PYTHON_VERSION" : 'pypy'; then
+#     ${PREFIX}mypy apistar tests --ignore-missing-imports
+# fi


### PR DESCRIPTION
Since its dependency `typed_ast` doesn't play well outside of CPython. Uses environment markers in the requirements file (https://www.python.org/dev/peps/pep-0508/#environment-markers) to exclude the PyPy environment.

Includes fixes to the Travis-CI configuration to make sure tests continue to run in all environments.