### PR TITLE
Renames test.Client to test.TestClient in docs

### DIFF
--- a/docs/api-guide/testing.md
+++ b/docs/api-guide/testing.md
@@ -15,7 +15,7 @@ from apistar import test
 from myproject import app
 
 
-client = test.Client(app)
+client = test.TestClient(app)
 
 def test_hello_world():
     response = client.get('/hello_world/')


### PR DESCRIPTION
Another small error in the docs on the 'Testing' page: `test.Client` to `test.TestClient`.