### PR TITLE
Enabling compiled regex for "pattern" on String type

### DIFF
--- a/apistar/validators.py
+++ b/apistar/validators.py
@@ -106,7 +106,7 @@ class String(Validator):
 
         assert max_length is None or isinstance(max_length, int)
         assert min_length is None or isinstance(min_length, int)
-        assert pattern is None or isinstance(pattern, str)
+        assert pattern is None or isinstance(pattern, (str, re._pattern_type))
         assert enum is None or isinstance(enum, list) and all([isinstance(i, str) for i in enum])
         assert format is None or isinstance(format, str)
 


### PR DESCRIPTION
Hi, the documentation says you can use compiled regex for "pattern" parameter on String type:

* `pattern` - A string or compiled regex that the data must match.

But when I try to use a compiled regex I get this error message:
```python
  File "/home/kurt/Projects/myproject/myproject/types.py", line 17, in Product
    name = validators.String(pattern=re.compile(r"^[a-zA-Z_][a-zA-Z0-9_-]{0,63}$"))
  File "/home/kurt/Projects/myproject/venv/lib/python3.6/site-packages/apistar/validators.py", line 109, in __init__
    assert pattern is None or isinstance(pattern, str)
AssertionError
```
Thank you.