### PR TITLE
Fixes for handler's OpenAPI description and requestBody

### DIFF
--- a/apistar/codecs/openapi.py
+++ b/apistar/codecs/openapi.py
@@ -404,7 +404,7 @@ class OpenAPICodec(BaseCodec):
                     )
                 }
 
-            operation['responseBody'] = {
+            operation['requestBody'] = {
                 'content': {
                     link.encoding: content_info
                 }

--- a/apistar/server/core.py
+++ b/apistar/server/core.py
@@ -23,7 +23,14 @@ class Route():
         encoding = None
         if any([f.location == 'body' for f in fields]):
             encoding = 'application/json'
-        return Link(url=url, method=method, name=name, encoding=encoding, fields=fields)
+        return Link(
+            url=url,
+            method=method,
+            name=name,
+            encoding=encoding,
+            fields=fields,
+            description=handler.__doc__
+        )
 
     def generate_fields(self, url, method, handler):
         fields = []

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -8,6 +8,7 @@ class User(types.Type):
 
 
 def get_endpoint(name: str, age: int=None):
+    """endpoint description"""
     raise NotImplementedError()
 
 
@@ -34,6 +35,7 @@ expected_schema = """{
     "paths": {
         "/get-endpoint/": {
             "get": {
+                "description": "endpoint description",
                 "operationId": "get_endpoint",
                 "parameters": [
                     {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -60,7 +60,7 @@ expected_schema = """{
         "/post-endpoint/": {
             "post": {
                 "operationId": "post_endpoint",
-                "responseBody": {
+                "requestBody": {
                     "content": {
                         "application/json": {
                             "schema": {


### PR DESCRIPTION
Both description and summary was missing at OpenAPI generated schema. This set the path description to the handler docstring. However I found no suitable text for summary.