### PR TITLE
Make minor cleanup and improve readability

### DIFF
--- a/apistar/client/transports.py
+++ b/apistar/client/transports.py
@@ -50,7 +50,7 @@ class HTTPTransport(BaseTransport):
         response = self.session.request(method, url, **options)
         result = self.decode_response_content(response)
 
-        if response.status_code >= 400 and response.status_code <= 599:
+        if 400 <= response.status_code <= 599:
             title = '%d %s' % (response.status_code, response.reason)
             raise exceptions.ErrorResponse(title, result)
 

--- a/apistar/codecs/base.py
+++ b/apistar/codecs/base.py
@@ -1,4 +1,4 @@
-class BaseCodec():
+class BaseCodec:
     media_type = None
 
     def decode(self, bytestring, **options):

--- a/apistar/codecs/jsonschema.py
+++ b/apistar/codecs/jsonschema.py
@@ -67,12 +67,15 @@ def get_typestrings(struct):
     """
     type_strings = struct.get('type', [])
     if isinstance(type_strings, str):
-        type_strings = set([type_strings])
+        type_strings = {type_strings}
     else:
         type_strings = set(type_strings)
 
     if not type_strings:
-        type_strings = set(['null', 'boolean', 'object', 'array', 'number', 'string'])
+        type_strings = {
+            'null', 'boolean', 'object',
+            'array', 'number', 'string'
+        }
 
     if 'integer' in type_strings and 'number' in type_strings:
         type_strings.remove('integer')
@@ -84,13 +87,13 @@ def is_any(type_strings, struct):
     """
     Return true if all types are valid, and there are no type constraints.
     """
-    ALL_PROPERTY_NAMES = set([
-        'exclusiveMaximum', 'format', 'minItems', 'pattern', 'required',
-        'multipleOf', 'maximum', 'minimum', 'maxItems', 'minLength',
-        'uniqueItems', 'additionalItems', 'maxLength', 'items',
-        'exclusiveMinimum', 'properties', 'additionalProperties',
-        'minProperties', 'maxProperties', 'patternProperties'
-    ])
+    ALL_PROPERTY_NAMES = {
+        'exclusiveMaximum', 'format', 'minItems', 'pattern', 'required', 'multipleOf', 'maximum',
+        'minimum', 'maxItems', 'minLength', 'uniqueItems', 'additionalItems', 'maxLength', 'items',
+        'exclusiveMinimum', 'properties', 'additionalProperties', 'minProperties', 'maxProperties',
+        'patternProperties'
+    }
+
     return len(type_strings) == 6 and not set(struct.keys()) & ALL_PROPERTY_NAMES
 
 

--- a/apistar/compat.py
+++ b/apistar/compat.py
@@ -38,8 +38,8 @@ try:
             mode = "" if self.closed else " '%s'" % self.file.mode
             return "<DownloadedFile '%s', %s%s>" % (self.name, state, mode)
 
-            def __str__(self):
-                return self.__repr__()
+        def __str__(self):
+            return self.__repr__()
 
 except ImportError:
     # On some platforms (eg GAE) the private _TemporaryFileWrapper may not be

--- a/apistar/document.py
+++ b/apistar/document.py
@@ -7,7 +7,7 @@ from apistar.validators import Validator
 LinkInfo = collections.namedtuple('LinkInfo', ['link', 'name', 'sections'])
 
 
-class Document():
+class Document:
     def __init__(self,
                  content: typing.Sequence[typing.Union['Section', 'Link']]=None,
                  url: str='',
@@ -52,7 +52,7 @@ class Document():
         return link_info_list
 
 
-class Section():
+class Section:
     def __init__(self,
                  name: str,
                  content: typing.Sequence[typing.Union['Section', 'Link']]=None,
@@ -97,7 +97,7 @@ class Section():
         return link_info_list
 
 
-class Link():
+class Link:
     """
     Links represent the actions that a client may perform.
     """
@@ -161,7 +161,7 @@ class Link():
         return None
 
 
-class Field():
+class Field:
     def __init__(self,
                  name: str,
                  location: str,

--- a/apistar/formats.py
+++ b/apistar/formats.py
@@ -20,7 +20,7 @@ DATETIME_REGEX = re.compile(
 )
 
 
-class BaseFormat():
+class BaseFormat:
     def is_native_type(self, value):
         raise NotImplementedError()
 

--- a/apistar/http.py
+++ b/apistar/http.py
@@ -168,7 +168,7 @@ class MutableHeaders(Headers):
             ]
 
 
-class Request():
+class Request:
     def __init__(self,
                  method: Method,
                  url: URL,
@@ -180,7 +180,7 @@ class Request():
         self.body = Body(b'') if (body is None) else body
 
 
-class Response():
+class Response:
     media_type = None
     charset = 'utf-8'
 

--- a/apistar/validators.py
+++ b/apistar/validators.py
@@ -15,7 +15,7 @@ FORMATS = {
 }
 
 
-class Validator():
+class Validator:
     errors = {}
     _creation_counter = 0
 


### PR DESCRIPTION
This small PR includes the following changes

* Use set literal instead of initiating set,
* Make `__str__` in `compat.py` reachable,
* Remove class definitions with empty parens.

