### PR TITLE
Apply automatic code formatting using black

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,6 @@
 [settings]
 atomic=true
-multi_line_output=5
+multi_line_output=3
 not_skip=__init__.py
 known_standard_library=types
 known_third_party=pytest

--- a/apistar/__init__.py
+++ b/apistar/__init__.py
@@ -11,8 +11,18 @@ from apistar.document import Document, Field, Link, Section
 from apistar.server import App, ASyncApp, Component, Include, Route
 from apistar.test import TestClient
 
-__version__ = '0.4.3'
+__version__ = "0.4.3"
 __all__ = [
-    'App', 'ASyncApp', 'Client', 'Component', 'Document', 'Section', 'Link', 'Field',
-    'Route', 'Include', 'TestClient', 'http'
+    "App",
+    "ASyncApp",
+    "Client",
+    "Component",
+    "Document",
+    "Section",
+    "Link",
+    "Field",
+    "Route",
+    "Include",
+    "TestClient",
+    "http",
 ]

--- a/apistar/client/__init__.py
+++ b/apistar/client/__init__.py
@@ -1,5 +1,3 @@
 from apistar.client.client import Client
 
-__all__ = [
-    'Client'
-]
+__all__ = ["Client"]

--- a/apistar/client/auth.py
+++ b/apistar/client/auth.py
@@ -8,7 +8,7 @@ class BasicAuthentication(HTTPBasicAuth):
 class TokenAuthentication(AuthBase):
     allow_cookies = False
 
-    def __init__(self, token, scheme='Bearer'):
+    def __init__(self, token, scheme="Bearer"):
         """
         * Use an unauthenticated client, and make a request to obtain a token.
         * Create an authenticated client using eg. `TokenAuthentication(token="<token>")`
@@ -17,7 +17,7 @@ class TokenAuthentication(AuthBase):
         self.scheme = scheme
 
     def __call__(self, request):
-        request.headers['Authorization'] = '%s %s' % (self.scheme, self.token)
+        request.headers["Authorization"] = "%s %s" % (self.scheme, self.token)
         return request
 
 
@@ -29,7 +29,7 @@ class SessionAuthentication(AuthBase):
     * Make a login request.
     """
     allow_cookies = True
-    safe_methods = ('GET', 'HEAD', 'OPTIONS', 'TRACE')
+    safe_methods = ("GET", "HEAD", "OPTIONS", "TRACE")
 
     def __init__(self, csrf_cookie_name=None, csrf_header_name=None):
         self.csrf_cookie_name = csrf_cookie_name
@@ -41,8 +41,12 @@ class SessionAuthentication(AuthBase):
             self.csrf_token = response.cookies[self.csrf_cookie_name]
 
     def __call__(self, request):
-        if self.csrf_token and self.csrf_header_name is not None and (request.method not in self.safe_methods):
+        if (
+            self.csrf_token
+            and self.csrf_header_name is not None
+            and (request.method not in self.safe_methods)
+        ):
             request.headers[self.csrf_header_name] = self.csrf_token
         if self.csrf_cookie_name is not None:
-            request.register_hook('response', self.store_csrf_token)
+            request.register_hook("response", self.store_csrf_token)
         return request

--- a/apistar/client/client.py
+++ b/apistar/client/client.py
@@ -5,22 +5,21 @@ from apistar.client import transports
 
 
 class Client():
+
     def __init__(self, document, auth=None, decoders=None, headers=None, session=None):
         self.document = document
         self.transport = self.init_transport(auth, decoders, headers, session)
 
     def init_transport(self, auth=None, decoders=None, headers=None, session=None):
         return transports.HTTPTransport(
-            auth=auth,
-            decoders=decoders,
-            headers=headers,
-            session=session
+            auth=auth, decoders=decoders, headers=headers, session=session
         )
 
     def lookup_link(self, name: str):
         for item in self.document.walk_links():
             if item.name == name:
                 return item.link
+
         raise exceptions.RequestError('Link "%s" not found in document.' % name)
 
     def get_url(self, link, params):
@@ -36,10 +35,10 @@ class Client():
 
         for field in link.get_path_fields():
             value = str(params[field.name])
-            if '{%s}' % field.name in url:
-                url = url.replace('{%s}' % field.name, quote(value, safe=''))
-            elif '{+%s}' % field.name in url:
-                url = url.replace('{+%s}' % field.name, quote(value, safe='/'))
+            if "{%s}" % field.name in url:
+                url = url.replace("{%s}" % field.name, quote(value, safe=""))
+            elif "{+%s}" % field.name in url:
+                url = url.replace("{+%s}" % field.name, quote(value, safe="/"))
 
         return url
 
@@ -54,6 +53,7 @@ class Client():
         body_field = link.get_body_field()
         if body_field and body_field.name in params:
             return (params[body_field.name], link.encoding)
+
         return (None, None)
 
     def request(self, name: str, **params):
@@ -62,7 +62,7 @@ class Client():
         validator = validators.Object(
             properties={field.name: validators.Any() for field in link.fields},
             required=[field.name for field in link.fields if field.required],
-            additional_properties=False
+            additional_properties=False,
         )
         validator.validate(params)
 
@@ -72,9 +72,5 @@ class Client():
         (content, encoding) = self.get_content_and_encoding(link, params)
 
         return self.transport.send(
-            method,
-            url,
-            query_params=query_params,
-            content=content,
-            encoding=encoding
+            method, url, query_params=query_params, content=content, encoding=encoding
         )

--- a/apistar/client/transports.py
+++ b/apistar/client/transports.py
@@ -4,7 +4,11 @@ import requests
 
 from apistar import codecs, conneg, exceptions
 from apistar.client.utils import (
-    BlockAllCookies, File, ForceMultiPartDict, guess_filename, is_file
+    BlockAllCookies,
+    File,
+    ForceMultiPartDict,
+    guess_filename,
+    is_file
 )
 
 

--- a/apistar/client/transports.py
+++ b/apistar/client/transports.py
@@ -16,12 +16,8 @@ class BaseTransport():
 
 
 class HTTPTransport(BaseTransport):
-    schemes = ['http', 'https']
-    default_decoders = [
-        codecs.JSONCodec(),
-        codecs.TextCodec(),
-        codecs.DownloadCodec()
-    ]
+    schemes = ["http", "https"]
+    default_decoders = [codecs.JSONCodec(), codecs.TextCodec(), codecs.DownloadCodec()]
 
     def __init__(self, auth=None, decoders=None, headers=None, session=None):
         from apistar import __version__
@@ -30,20 +26,17 @@ class HTTPTransport(BaseTransport):
             session = requests.Session()
         if auth is not None:
             session.auth = auth
-        if not getattr(session.auth, 'allow_cookies', False):
+        if not getattr(session.auth, "allow_cookies", False):
             session.cookies.set_policy(BlockAllCookies())
 
         self.session = session
         self.decoders = list(decoders) if decoders else list(self.default_decoders)
         self.headers = {
-            'accept': '%s, */*' % self.decoders[0].media_type,
-            'user-agent': 'apistar %s' % __version__
+            "accept": "%s, */*" % self.decoders[0].media_type,
+            "user-agent": "apistar %s" % __version__,
         }
         if headers:
-            self.headers.update({
-                key.lower(): value
-                for key, value in headers.items()
-            })
+            self.headers.update({key.lower(): value for key, value in headers.items()})
 
     def send(self, method, url, query_params=None, content=None, encoding=None):
         options = self.get_request_options(query_params, content, encoding)
@@ -51,7 +44,7 @@ class HTTPTransport(BaseTransport):
         result = self.decode_response_content(response)
 
         if 400 <= response.status_code <= 599:
-            title = '%d %s' % (response.status_code, response.reason)
+            title = "%d %s" % (response.status_code, response.reason)
             raise exceptions.ErrorResponse(title, result)
 
         return result
@@ -61,17 +54,15 @@ class HTTPTransport(BaseTransport):
         Returns a dictionary of keyword parameters to include when making
         the outgoing request.
         """
-        options = {
-            'headers': dict(self.headers)
-        }
+        options = {"headers": dict(self.headers)}
 
         if query_params:
-            options['params'] = query_params
+            options["params"] = query_params
 
         if content is not None:
-            if encoding == 'application/json':
-                options['json'] = content
-            elif encoding == 'multipart/form-data':
+            if encoding == "application/json":
+                options["json"] = content
+            elif encoding == "multipart/form-data":
                 data = {}
                 files = ForceMultiPartDict()
                 for key, value in content.items():
@@ -79,15 +70,15 @@ class HTTPTransport(BaseTransport):
                         files[key] = value
                     else:
                         data[key] = value
-            elif encoding == 'application/x-www-form-urlencoded':
-                options['data'] = content
-            elif encoding == 'application/octet-stream':
+            elif encoding == "application/x-www-form-urlencoded":
+                options["data"] = content
+            elif encoding == "application/octet-stream":
                 if isinstance(content, File):
-                    options['data'] = content.content
+                    options["data"] = content.content
                 else:
-                    options['data'] = content
+                    options["data"] = content
                 upload_headers = self.get_upload_headers(content)
-                options['headers'].update(upload_headers)
+                options["headers"].update(upload_headers)
 
         return options
 
@@ -101,7 +92,7 @@ class HTTPTransport(BaseTransport):
         content_disposition = None
 
         # Determine the content type of the upload.
-        if getattr(file_obj, 'content_type', None):
+        if getattr(file_obj, "content_type", None):
             content_type = file_obj.content_type
         elif name:
             content_type, encoding = mimetypes.guess_type(name)
@@ -111,8 +102,8 @@ class HTTPTransport(BaseTransport):
             content_disposition = 'attachment; filename="%s"' % name
 
         return {
-            'Content-Type': content_type or 'application/octet-stream',
-            'Content-Disposition': content_disposition or 'attachment'
+            "Content-Type": content_type or "application/octet-stream",
+            "Content-Disposition": content_disposition or "attachment",
         }
 
     def decode_response_content(self, response):
@@ -122,15 +113,13 @@ class HTTPTransport(BaseTransport):
         if not response.content:
             return None
 
-        content_type = response.headers.get('content-type')
+        content_type = response.headers.get("content-type")
         codec = conneg.negotiate_content_type(self.decoders, content_type)
 
-        options = {
-            'base_url': response.url
-        }
-        if 'content-type' in response.headers:
-            options['content_type'] = response.headers['content-type']
-        if 'content-disposition' in response.headers:
-            options['content_disposition'] = response.headers['content-disposition']
+        options = {"base_url": response.url}
+        if "content-type" in response.headers:
+            options["content_type"] = response.headers["content-type"]
+        if "content-disposition" in response.headers:
+            options["content_disposition"] = response.headers["content-disposition"]
 
         return codec.decode(response.content, **options)

--- a/apistar/client/utils.py
+++ b/apistar/client/utils.py
@@ -2,7 +2,7 @@ import os
 from collections import namedtuple
 from http import cookiejar
 
-File = namedtuple('File', 'name content content_type')
+File = namedtuple("File", "name content content_type")
 File.__new__.__defaults__ = (None,)
 
 
@@ -10,7 +10,7 @@ def is_file(obj):
     if isinstance(obj, File):
         return True
 
-    if hasattr(obj, '__iter__') and not isinstance(obj, (str, list, tuple, dict)):
+    if hasattr(obj, "__iter__") and not isinstance(obj, (str, list, tuple, dict)):
         # A stream object.
         return True
 
@@ -18,9 +18,10 @@ def is_file(obj):
 
 
 def guess_filename(obj):
-    name = getattr(obj, 'name', None)
-    if name and isinstance(name, str) and name[0] != '<' and name[-1] != '>':
+    name = getattr(obj, "name", None)
+    if name and isinstance(name, str) and name[0] != "<" and name[-1] != ">":
         return os.path.basename(name)
+
     return None
 
 
@@ -30,6 +31,7 @@ class ForceMultiPartDict(dict):
     Allows us to force requests to use multipart encoding, even when no
     file parameters are passed.
     """
+
     def __bool__(self):
         return True
 

--- a/apistar/codecs/__init__.py
+++ b/apistar/codecs/__init__.py
@@ -6,6 +6,10 @@ from apistar.codecs.openapi import OpenAPICodec
 from apistar.codecs.text import TextCodec
 
 __all__ = [
-    'BaseCodec', 'JSONCodec', 'JSONSchemaCodec', 'OpenAPICodec', 'TextCodec',
-    'DownloadCodec'
+    "BaseCodec",
+    "JSONCodec",
+    "JSONSchemaCodec",
+    "OpenAPICodec",
+    "TextCodec",
+    "DownloadCodec",
 ]

--- a/apistar/codecs/download.py
+++ b/apistar/codecs/download.py
@@ -15,86 +15,88 @@ def _guess_extension(content_type):
     but take a reasonable preference on what extension to map to.
     """
     return {
-        'application/javascript': '.js',
-        'application/msword': '.doc',
-        'application/octet-stream': '.bin',
-        'application/oda': '.oda',
-        'application/pdf': '.pdf',
-        'application/pkcs7-mime': '.p7c',
-        'application/postscript': '.ps',
-        'application/vnd.apple.mpegurl': '.m3u',
-        'application/vnd.ms-excel': '.xls',
-        'application/vnd.ms-powerpoint': '.ppt',
-        'application/x-bcpio': '.bcpio',
-        'application/x-cpio': '.cpio',
-        'application/x-csh': '.csh',
-        'application/x-dvi': '.dvi',
-        'application/x-gtar': '.gtar',
-        'application/x-hdf': '.hdf',
-        'application/x-latex': '.latex',
-        'application/x-mif': '.mif',
-        'application/x-netcdf': '.nc',
-        'application/x-pkcs12': '.p12',
-        'application/x-pn-realaudio': '.ram',
-        'application/x-python-code': '.pyc',
-        'application/x-sh': '.sh',
-        'application/x-shar': '.shar',
-        'application/x-shockwave-flash': '.swf',
-        'application/x-sv4cpio': '.sv4cpio',
-        'application/x-sv4crc': '.sv4crc',
-        'application/x-tar': '.tar',
-        'application/x-tcl': '.tcl',
-        'application/x-tex': '.tex',
-        'application/x-texinfo': '.texinfo',
-        'application/x-troff': '.tr',
-        'application/x-troff-man': '.man',
-        'application/x-troff-me': '.me',
-        'application/x-troff-ms': '.ms',
-        'application/x-ustar': '.ustar',
-        'application/x-wais-source': '.src',
-        'application/xml': '.xml',
-        'application/zip': '.zip',
-        'audio/basic': '.au',
-        'audio/mpeg': '.mp3',
-        'audio/x-aiff': '.aif',
-        'audio/x-pn-realaudio': '.ra',
-        'audio/x-wav': '.wav',
-        'image/gif': '.gif',
-        'image/ief': '.ief',
-        'image/jpeg': '.jpe',
-        'image/png': '.png',
-        'image/svg+xml': '.svg',
-        'image/tiff': '.tiff',
-        'image/vnd.microsoft.icon': '.ico',
-        'image/x-cmu-raster': '.ras',
-        'image/x-ms-bmp': '.bmp',
-        'image/x-portable-anymap': '.pnm',
-        'image/x-portable-bitmap': '.pbm',
-        'image/x-portable-graymap': '.pgm',
-        'image/x-portable-pixmap': '.ppm',
-        'image/x-rgb': '.rgb',
-        'image/x-xbitmap': '.xbm',
-        'image/x-xpixmap': '.xpm',
-        'image/x-xwindowdump': '.xwd',
-        'message/rfc822': '.eml',
-        'text/css': '.css',
-        'text/csv': '.csv',
-        'text/html': '.html',
-        'text/plain': '.txt',
-        'text/richtext': '.rtx',
-        'text/tab-separated-values': '.tsv',
-        'text/x-python': '.py',
-        'text/x-setext': '.etx',
-        'text/x-sgml': '.sgml',
-        'text/x-vcard': '.vcf',
-        'text/xml': '.xml',
-        'video/mp4': '.mp4',
-        'video/mpeg': '.mpeg',
-        'video/quicktime': '.mov',
-        'video/webm': '.webm',
-        'video/x-msvideo': '.avi',
-        'video/x-sgi-movie': '.movie'
-    }.get(content_type, '')
+        "application/javascript": ".js",
+        "application/msword": ".doc",
+        "application/octet-stream": ".bin",
+        "application/oda": ".oda",
+        "application/pdf": ".pdf",
+        "application/pkcs7-mime": ".p7c",
+        "application/postscript": ".ps",
+        "application/vnd.apple.mpegurl": ".m3u",
+        "application/vnd.ms-excel": ".xls",
+        "application/vnd.ms-powerpoint": ".ppt",
+        "application/x-bcpio": ".bcpio",
+        "application/x-cpio": ".cpio",
+        "application/x-csh": ".csh",
+        "application/x-dvi": ".dvi",
+        "application/x-gtar": ".gtar",
+        "application/x-hdf": ".hdf",
+        "application/x-latex": ".latex",
+        "application/x-mif": ".mif",
+        "application/x-netcdf": ".nc",
+        "application/x-pkcs12": ".p12",
+        "application/x-pn-realaudio": ".ram",
+        "application/x-python-code": ".pyc",
+        "application/x-sh": ".sh",
+        "application/x-shar": ".shar",
+        "application/x-shockwave-flash": ".swf",
+        "application/x-sv4cpio": ".sv4cpio",
+        "application/x-sv4crc": ".sv4crc",
+        "application/x-tar": ".tar",
+        "application/x-tcl": ".tcl",
+        "application/x-tex": ".tex",
+        "application/x-texinfo": ".texinfo",
+        "application/x-troff": ".tr",
+        "application/x-troff-man": ".man",
+        "application/x-troff-me": ".me",
+        "application/x-troff-ms": ".ms",
+        "application/x-ustar": ".ustar",
+        "application/x-wais-source": ".src",
+        "application/xml": ".xml",
+        "application/zip": ".zip",
+        "audio/basic": ".au",
+        "audio/mpeg": ".mp3",
+        "audio/x-aiff": ".aif",
+        "audio/x-pn-realaudio": ".ra",
+        "audio/x-wav": ".wav",
+        "image/gif": ".gif",
+        "image/ief": ".ief",
+        "image/jpeg": ".jpe",
+        "image/png": ".png",
+        "image/svg+xml": ".svg",
+        "image/tiff": ".tiff",
+        "image/vnd.microsoft.icon": ".ico",
+        "image/x-cmu-raster": ".ras",
+        "image/x-ms-bmp": ".bmp",
+        "image/x-portable-anymap": ".pnm",
+        "image/x-portable-bitmap": ".pbm",
+        "image/x-portable-graymap": ".pgm",
+        "image/x-portable-pixmap": ".ppm",
+        "image/x-rgb": ".rgb",
+        "image/x-xbitmap": ".xbm",
+        "image/x-xpixmap": ".xpm",
+        "image/x-xwindowdump": ".xwd",
+        "message/rfc822": ".eml",
+        "text/css": ".css",
+        "text/csv": ".csv",
+        "text/html": ".html",
+        "text/plain": ".txt",
+        "text/richtext": ".rtx",
+        "text/tab-separated-values": ".tsv",
+        "text/x-python": ".py",
+        "text/x-setext": ".etx",
+        "text/x-sgml": ".sgml",
+        "text/x-vcard": ".vcf",
+        "text/xml": ".xml",
+        "video/mp4": ".mp4",
+        "video/mpeg": ".mpeg",
+        "video/quicktime": ".mov",
+        "video/webm": ".webm",
+        "video/x-msvideo": ".avi",
+        "video/x-sgi-movie": ".movie",
+    }.get(
+        content_type, ""
+    )
 
 
 def _unique_output_path(path):
@@ -120,11 +122,12 @@ def _safe_filename(filename):
     """
     filename = os.path.basename(filename)
 
-    keepcharacters = (' ', '.', '_', '-')
-    filename = ''.join(
-        char for char in filename
-        if char.isalnum() or char in keepcharacters
-    ).strip().strip('.')
+    keepcharacters = (" ", ".", "_", "-")
+    filename = "".join(
+        char for char in filename if char.isalnum() or char in keepcharacters
+    ).strip().strip(
+        "."
+    )
 
     return filename
 
@@ -135,17 +138,18 @@ def _get_filename_from_content_disposition(content_disposition):
     """
     params = value, params = cgi.parse_header(content_disposition)
 
-    if 'filename*' in params:
+    if "filename*" in params:
         try:
-            charset, lang, filename = params['filename*'].split('\'', 2)
+            charset, lang, filename = params["filename*"].split("'", 2)
             filename = unquote(filename)
-            filename = filename.encode('iso-8859-1').decode(charset)
+            filename = filename.encode("iso-8859-1").decode(charset)
             return _safe_filename(filename)
+
         except (ValueError, LookupError):
             pass
 
-    if 'filename' in params:
-        filename = params['filename']
+    if "filename" in params:
+        filename = params["filename"]
         return _safe_filename(filename)
 
     return None
@@ -156,16 +160,18 @@ def _get_filename_from_url(url, content_type=None):
     Determine an output filename based on the download URL.
     """
     parsed = urlparse(url)
-    final_path_component = posixpath.basename(parsed.path.rstrip('/'))
+    final_path_component = posixpath.basename(parsed.path.rstrip("/"))
     filename = _safe_filename(final_path_component)
-    suffix = _guess_extension(content_type or '')
+    suffix = _guess_extension(content_type or "")
 
     if filename:
-        if '.' not in filename:
+        if "." not in filename:
             return filename + suffix
+
         return filename
+
     elif suffix:
-        return 'download' + suffix
+        return "download" + suffix
 
     return None
 
@@ -181,6 +187,7 @@ def _get_filename(base_url=None, content_type=None, content_disposition=None):
         filename = _get_filename_from_url(base_url, content_type)
     if not filename:
         return None  # Ensure empty filenames return as `None` for consistency.
+
     return filename
 
 
@@ -188,8 +195,8 @@ class DownloadCodec(BaseCodec):
     """
     A codec to handle raw file downloads, such as images and other media.
     """
-    media_type = '*/*'
-    format = 'download'
+    media_type = "*/*"
+    format = "download"
 
     def __init__(self, download_dir=None):
         """
@@ -203,13 +210,13 @@ class DownloadCodec(BaseCodec):
         return self._download_dir
 
     def decode(self, bytestring, **options):
-        base_url = options.get('base_url')
-        content_type = options.get('content_type')
-        content_disposition = options.get('content_disposition')
+        base_url = options.get("base_url")
+        content_type = options.get("content_type")
+        content_disposition = options.get("content_disposition")
 
         # Write the download to a temporary .download file.
-        fd, temp_path = tempfile.mkstemp(suffix='.download')
-        file_handle = os.fdopen(fd, 'wb')
+        fd, temp_path = tempfile.mkstemp(suffix=".download")
+        file_handle = os.fdopen(fd, "wb")
         file_handle.write(bytestring)
         file_handle.close()
 
@@ -232,7 +239,9 @@ class DownloadCodec(BaseCodec):
             os.rename(temp_path, output_path)
 
         # Open the file and return the file object.
-        output_file = open(output_path, 'rb')
-        downloaded = DownloadedFile(output_file, output_path, delete=self._delete_on_close)
+        output_file = open(output_path, "rb")
+        downloaded = DownloadedFile(
+            output_file, output_path, delete=self._delete_on_close
+        )
         downloaded.basename = output_filename
         return downloaded

--- a/apistar/codecs/jsondata.py
+++ b/apistar/codecs/jsondata.py
@@ -6,8 +6,8 @@ from apistar.exceptions import ParseError
 
 
 class JSONCodec(BaseCodec):
-    media_type = 'application/json'
-    format = 'json'
+    media_type = "application/json"
+    format = "json"
 
     def decode(self, bytestring, **options):
         """
@@ -15,8 +15,8 @@ class JSONCodec(BaseCodec):
         """
         try:
             return json.loads(
-                bytestring.decode('utf-8'),
-                object_pairs_hook=collections.OrderedDict
+                bytestring.decode("utf-8"), object_pairs_hook=collections.OrderedDict
             )
+
         except ValueError as exc:
-            raise ParseError('Malformed JSON. %s' % exc) from None
+            raise ParseError("Malformed JSON. %s" % exc) from None

--- a/apistar/codecs/jsonschema.py
+++ b/apistar/codecs/jsonschema.py
@@ -6,41 +6,53 @@ from apistar.compat import dict_type
 from apistar.exceptions import ParseError
 
 JSON_SCHEMA = validators.Object(
-    def_name='JSONSchema',
+    def_name="JSONSchema",
     properties=[
-        ('$ref', validators.String()),
-        ('type', validators.String() | validators.Array(items=validators.String())),
-        ('enum', validators.Array(unique_items=True, min_items=1)),
-        ('definitions', validators.Object(additional_properties=validators.Ref('JSONSchema'))),
-
+        ("$ref", validators.String()),
+        ("type", validators.String() | validators.Array(items=validators.String())),
+        ("enum", validators.Array(unique_items=True, min_items=1)),
+        (
+            "definitions",
+            validators.Object(additional_properties=validators.Ref("JSONSchema")),
+        ),
         # String
-        ('minLength', validators.Integer(minimum=0)),
-        ('maxLength', validators.Integer(minimum=0)),
-        ('pattern', validators.String(format='regex')),
-        ('format', validators.String()),
-
+        ("minLength", validators.Integer(minimum=0)),
+        ("maxLength", validators.Integer(minimum=0)),
+        ("pattern", validators.String(format="regex")),
+        ("format", validators.String()),
         # Numeric
-        ('minimum', validators.Number()),
-        ('maximum', validators.Number()),
-        ('exclusiveMinimum', validators.Boolean()),
-        ('exclusiveMaximum', validators.Boolean()),
-        ('multipleOf', validators.Number(minimum=0.0, exclusive_minimum=True)),
-
+        ("minimum", validators.Number()),
+        ("maximum", validators.Number()),
+        ("exclusiveMinimum", validators.Boolean()),
+        ("exclusiveMaximum", validators.Boolean()),
+        ("multipleOf", validators.Number(minimum=0.0, exclusive_minimum=True)),
         # Object
-        ('properties', validators.Object(additional_properties=validators.Ref('JSONSchema'))),
-        ('minProperties', validators.Integer(minimum=0)),
-        ('maxProperties', validators.Integer(minimum=0)),
-        ('patternProperties', validators.Object(additional_properties=validators.Ref('JSONSchema'))),
-        ('additionalProperties', validators.Ref('JSONSchema') | validators.Boolean()),
-        ('required', validators.Array(items=validators.String(), min_items=1, unique_items=True)),
-
+        (
+            "properties",
+            validators.Object(additional_properties=validators.Ref("JSONSchema")),
+        ),
+        ("minProperties", validators.Integer(minimum=0)),
+        ("maxProperties", validators.Integer(minimum=0)),
+        (
+            "patternProperties",
+            validators.Object(additional_properties=validators.Ref("JSONSchema")),
+        ),
+        ("additionalProperties", validators.Ref("JSONSchema") | validators.Boolean()),
+        (
+            "required",
+            validators.Array(items=validators.String(), min_items=1, unique_items=True),
+        ),
         # Array
-        ('items', validators.Ref('JSONSchema') | validators.Array(items=validators.Ref('JSONSchema'), min_items=1)),
-        ('additionalItems', validators.Ref('JSONSchema') | validators.Boolean()),
-        ('minItems', validators.Integer(minimum=0)),
-        ('maxItems', validators.Integer(minimum=0)),
-        ('uniqueItems', validators.Boolean()),
-    ]
+        (
+            "items",
+            validators.Ref("JSONSchema")
+            | validators.Array(items=validators.Ref("JSONSchema"), min_items=1),
+        ),
+        ("additionalItems", validators.Ref("JSONSchema") | validators.Boolean()),
+        ("minItems", validators.Integer(minimum=0)),
+        ("maxItems", validators.Integer(minimum=0)),
+        ("uniqueItems", validators.Boolean()),
+    ],
 )
 
 
@@ -50,12 +62,13 @@ def decode(struct):
         return validators.Any()
 
     allow_null = False
-    if 'null' in typestrings:
+    if "null" in typestrings:
         allow_null = True
-        typestrings.remove('null')
+        typestrings.remove("null")
 
     if len(typestrings) == 1:
         return load_type(typestrings.pop(), struct, allow_null)
+
     else:
         items = [load_type(typename, struct, False) for typename in typestrings]
         return validators.Union(items=items, allow_null=allow_null)
@@ -65,20 +78,17 @@ def get_typestrings(struct):
     """
     Return the valid schema types as a set.
     """
-    type_strings = struct.get('type', [])
+    type_strings = struct.get("type", [])
     if isinstance(type_strings, str):
         type_strings = {type_strings}
     else:
         type_strings = set(type_strings)
 
     if not type_strings:
-        type_strings = {
-            'null', 'boolean', 'object',
-            'array', 'number', 'string'
-        }
+        type_strings = {"null", "boolean", "object", "array", "number", "string"}
 
-    if 'integer' in type_strings and 'number' in type_strings:
-        type_strings.remove('integer')
+    if "integer" in type_strings and "number" in type_strings:
+        type_strings.remove("integer")
 
     return type_strings
 
@@ -88,109 +98,125 @@ def is_any(type_strings, struct):
     Return true if all types are valid, and there are no type constraints.
     """
     ALL_PROPERTY_NAMES = {
-        'exclusiveMaximum', 'format', 'minItems', 'pattern', 'required', 'multipleOf', 'maximum',
-        'minimum', 'maxItems', 'minLength', 'uniqueItems', 'additionalItems', 'maxLength', 'items',
-        'exclusiveMinimum', 'properties', 'additionalProperties', 'minProperties', 'maxProperties',
-        'patternProperties'
+        "exclusiveMaximum",
+        "format",
+        "minItems",
+        "pattern",
+        "required",
+        "multipleOf",
+        "maximum",
+        "minimum",
+        "maxItems",
+        "minLength",
+        "uniqueItems",
+        "additionalItems",
+        "maxLength",
+        "items",
+        "exclusiveMinimum",
+        "properties",
+        "additionalProperties",
+        "minProperties",
+        "maxProperties",
+        "patternProperties",
     }
 
     return len(type_strings) == 6 and not set(struct.keys()) & ALL_PROPERTY_NAMES
 
 
 def load_type(typename, struct, allow_null):
-    attrs = {'allow_null': True} if allow_null else {}
+    attrs = {"allow_null": True} if allow_null else {}
 
-    if typename == 'string':
-        if 'minLength' in struct:
-            attrs['min_length'] = struct['minLength']
-        if 'maxLength' in struct:
-            attrs['max_length'] = struct['maxLength']
-        if 'pattern' in struct:
-            attrs['pattern'] = struct['pattern']
-        if 'format' in struct:
-            attrs['format'] = struct['format']
+    if typename == "string":
+        if "minLength" in struct:
+            attrs["min_length"] = struct["minLength"]
+        if "maxLength" in struct:
+            attrs["max_length"] = struct["maxLength"]
+        if "pattern" in struct:
+            attrs["pattern"] = struct["pattern"]
+        if "format" in struct:
+            attrs["format"] = struct["format"]
         return validators.String(**attrs)
 
-    if typename in ['number', 'integer']:
-        if 'minimum' in struct:
-            attrs['minimum'] = struct['minimum']
-        if 'maximum' in struct:
-            attrs['maximum'] = struct['maximum']
-        if 'exclusiveMinimum' in struct:
-            attrs['exclusive_minimum'] = struct['exclusiveMinimum']
-        if 'exclusiveMaximum' in struct:
-            attrs['exclusive_maximum'] = struct['exclusiveMaximum']
-        if 'multipleOf' in struct:
-            attrs['multiple_of'] = struct['multipleOf']
-        if 'format' in struct:
-            attrs['format'] = struct['format']
-        if typename == 'integer':
+    if typename in ["number", "integer"]:
+        if "minimum" in struct:
+            attrs["minimum"] = struct["minimum"]
+        if "maximum" in struct:
+            attrs["maximum"] = struct["maximum"]
+        if "exclusiveMinimum" in struct:
+            attrs["exclusive_minimum"] = struct["exclusiveMinimum"]
+        if "exclusiveMaximum" in struct:
+            attrs["exclusive_maximum"] = struct["exclusiveMaximum"]
+        if "multipleOf" in struct:
+            attrs["multiple_of"] = struct["multipleOf"]
+        if "format" in struct:
+            attrs["format"] = struct["format"]
+        if typename == "integer":
             return validators.Integer(**attrs)
+
         return validators.Number(**attrs)
 
-    if typename == 'boolean':
+    if typename == "boolean":
         return validators.Boolean(**attrs)
 
-    if typename == 'object':
-        if 'properties' in struct:
-            attrs['properties'] = dict_type([
-                (key, decode(value))
-                for key, value in struct['properties'].items()
-            ])
-        if 'required' in struct:
-            attrs['required'] = struct['required']
-        if 'minProperties' in struct:
-            attrs['min_properties'] = struct['minProperties']
-        if 'maxProperties' in struct:
-            attrs['max_properties'] = struct['maxProperties']
-        if 'required' in struct:
-            attrs['required'] = struct['required']
-        if 'patternProperties' in struct:
-            attrs['pattern_properties'] = dict_type([
-                (key, decode(value))
-                for key, value in struct['patternProperties'].items()
-            ])
-        if 'additionalProperties' in struct:
-            if isinstance(struct['additionalProperties'], bool):
-                attrs['additional_properties'] = struct['additionalProperties']
+    if typename == "object":
+        if "properties" in struct:
+            attrs["properties"] = dict_type(
+                [(key, decode(value)) for key, value in struct["properties"].items()]
+            )
+        if "required" in struct:
+            attrs["required"] = struct["required"]
+        if "minProperties" in struct:
+            attrs["min_properties"] = struct["minProperties"]
+        if "maxProperties" in struct:
+            attrs["max_properties"] = struct["maxProperties"]
+        if "required" in struct:
+            attrs["required"] = struct["required"]
+        if "patternProperties" in struct:
+            attrs["pattern_properties"] = dict_type(
+                [
+                    (key, decode(value))
+                    for key, value in struct["patternProperties"].items()
+                ]
+            )
+        if "additionalProperties" in struct:
+            if isinstance(struct["additionalProperties"], bool):
+                attrs["additional_properties"] = struct["additionalProperties"]
             else:
-                attrs['additional_properties'] = decode(struct['additionalProperties'])
+                attrs["additional_properties"] = decode(struct["additionalProperties"])
         return validators.Object(**attrs)
 
-    if typename == 'array':
-        if 'items' in struct:
-            if isinstance(struct['items'], list):
-                attrs['items'] = [decode(item) for item in struct['items']]
+    if typename == "array":
+        if "items" in struct:
+            if isinstance(struct["items"], list):
+                attrs["items"] = [decode(item) for item in struct["items"]]
             else:
-                attrs['items'] = decode(struct['items'])
-        if 'additionalItems' in struct:
-            if isinstance(struct['additionalItems'], bool):
-                attrs['additional_items'] = struct['additionalItems']
+                attrs["items"] = decode(struct["items"])
+        if "additionalItems" in struct:
+            if isinstance(struct["additionalItems"], bool):
+                attrs["additional_items"] = struct["additionalItems"]
             else:
-                attrs['additional_items'] = decode(struct['additionalItems'])
-        if 'minItems' in struct:
-            attrs['min_items'] = struct['minItems']
-        if 'maxItems' in struct:
-            attrs['max_items'] = struct['maxItems']
-        if 'uniqueItems' in struct:
-            attrs['unique_items'] = struct['uniqueItems']
+                attrs["additional_items"] = decode(struct["additionalItems"])
+        if "minItems" in struct:
+            attrs["min_items"] = struct["minItems"]
+        if "maxItems" in struct:
+            attrs["max_items"] = struct["maxItems"]
+        if "uniqueItems" in struct:
+            attrs["unique_items"] = struct["uniqueItems"]
         return validators.Array(**attrs)
 
     assert False
 
 
 class JSONSchemaCodec(BaseCodec):
-    media_type = 'application/schema+json'
-    format = 'jsonschema'
+    media_type = "application/schema+json"
+    format = "jsonschema"
 
     def decode(self, bytestring, **options):
         try:
-            data = json.loads(
-                bytestring.decode('utf-8'),
-                object_pairs_hook=dict_type
-            )
+            data = json.loads(bytestring.decode("utf-8"), object_pairs_hook=dict_type)
         except ValueError as exc:
-            raise ParseError('Malformed JSON. %s' % exc) from None
+            raise ParseError("Malformed JSON. %s" % exc) from None
+
         jsonschema = JSON_SCHEMA.validate(data)
         return decode(jsonschema)
 
@@ -200,25 +226,19 @@ class JSONSchemaCodec(BaseCodec):
 
     def encode(self, item, **options):
         defs = dict_type()
-        struct = self.encode_to_data_structure(item, defs=defs, def_prefix='#/definitions/')
-        struct['definitions'] = defs
-        if options.get('to_data_structure'):
+        struct = self.encode_to_data_structure(
+            item, defs=defs, def_prefix="#/definitions/"
+        )
+        struct["definitions"] = defs
+        if options.get("to_data_structure"):
             return struct
 
-        indent = options.get('indent')
+        indent = options.get("indent")
         if indent:
-            kwargs = {
-                'ensure_ascii': False,
-                'indent': 4,
-                'separators': (',', ': ')
-            }
+            kwargs = {"ensure_ascii": False, "indent": 4, "separators": (",", ": ")}
         else:
-            kwargs = {
-                'ensure_ascii': False,
-                'indent': None,
-                'separators': (',', ':')
-            }
-        return json.dumps(struct, **kwargs).encode('utf-8')
+            kwargs = {"ensure_ascii": False, "indent": None, "separators": (",", ":")}
+        return json.dumps(struct, **kwargs).encode("utf-8")
 
     def encode_to_data_structure(self, item, defs=None, def_prefix=None, is_def=False):
         if issubclass(item, types.Type):
@@ -228,77 +248,81 @@ class JSONSchemaCodec(BaseCodec):
             defs[item.def_name] = self.encode_to_data_structure(
                 item, defs, def_prefix, is_def=True
             )
-            return {'$ref': def_prefix + item.def_name}
+            return {"$ref": def_prefix + item.def_name}
 
         value = dict_type()
         if item.title:
-            value['title'] = item.title
+            value["title"] = item.title
         if item.description:
-            value['description'] = item.description
+            value["description"] = item.description
         if item.has_default():
-            value['default'] = item.default
-        if getattr(item, 'allow_null') is True:
-            value['nullable'] = True
+            value["default"] = item.default
+        if getattr(item, "allow_null") is True:
+            value["nullable"] = True
 
         if isinstance(item, validators.String):
-            value['type'] = 'string'
+            value["type"] = "string"
             if item.max_length is not None:
-                value['maxLength'] = item.max_length
+                value["maxLength"] = item.max_length
             if item.min_length is not None:
-                value['minLength'] = item.min_length
+                value["minLength"] = item.min_length
             if item.pattern is not None:
-                value['pattern'] = item.pattern
+                value["pattern"] = item.pattern
             if item.format is not None:
-                value['format'] = item.format
+                value["format"] = item.format
             return value
 
         elif isinstance(item, validators.NumericType):
             if isinstance(item, validators.Integer):
-                value['type'] = 'integer'
+                value["type"] = "integer"
             else:
-                value['type'] = 'number'
+                value["type"] = "number"
 
             if item.minimum is not None:
-                value['minimum'] = item.minimum
+                value["minimum"] = item.minimum
             if item.maximum is not None:
-                value['maximum'] = item.maximum
+                value["maximum"] = item.maximum
             if item.exclusive_minimum:
-                value['exclusiveMinimum'] = item.exclusive_minimum
+                value["exclusiveMinimum"] = item.exclusive_minimum
             if item.exclusive_maximum:
-                value['exclusiveMaximum'] = item.exclusive_maximum
+                value["exclusiveMaximum"] = item.exclusive_maximum
             if item.multiple_of is not None:
-                value['multipleOf'] = item.multiple_of
+                value["multipleOf"] = item.multiple_of
             if item.format is not None:
-                value['format'] = item.format
+                value["format"] = item.format
             return value
 
         elif isinstance(item, validators.Boolean):
-            value['type'] = 'boolean'
+            value["type"] = "boolean"
             return value
 
         elif isinstance(item, validators.Object):
-            value['type'] = 'object'
+            value["type"] = "object"
             if item.properties:
-                value['properties'] = dict_type([
-                    (key, self.encode_to_data_structure(value, defs, def_prefix))
-                    for key, value in item.properties.items()
-                ])
+                value["properties"] = dict_type(
+                    [
+                        (key, self.encode_to_data_structure(value, defs, def_prefix))
+                        for key, value in item.properties.items()
+                    ]
+                )
             if item.required:
-                value['required'] = item.required
+                value["required"] = item.required
             return value
 
         elif isinstance(item, validators.Array):
-            value['type'] = 'array'
+            value["type"] = "array"
             if item.items is not None:
-                value['items'] = self.encode_to_data_structure(item.items, defs, def_prefix)
+                value["items"] = self.encode_to_data_structure(
+                    item.items, defs, def_prefix
+                )
             if item.additional_items:
-                value['additionalItems'] = item.additional_items
+                value["additionalItems"] = item.additional_items
             if item.min_items is not None:
-                value['minItems'] = item.min_items
+                value["minItems"] = item.min_items
             if item.max_items is not None:
-                value['maxItems'] = item.max_items
+                value["maxItems"] = item.max_items
             if item.unique_items is not None:
-                value['uniqueItems'] = item.unique_items
+                value["uniqueItems"] = item.unique_items
             return value
 
-        raise Exception('Cannot encode item %s' % item)
+        raise Exception("Cannot encode item %s" % item)

--- a/apistar/codecs/openapi.py
+++ b/apistar/codecs/openapi.py
@@ -10,161 +10,174 @@ from apistar.document import Document, Field, Link, Section
 from apistar.exceptions import ParseError
 
 SCHEMA_REF = validators.Object(
-    properties={'$ref': validators.String(pattern='^#/components/schemas/')}
+    properties={"$ref": validators.String(pattern="^#/components/schemas/")}
 )
 
 
 OPEN_API = validators.Object(
-    def_name='OpenAPI',
-    title='OpenAPI',
+    def_name="OpenAPI",
+    title="OpenAPI",
     properties=[
-        ('openapi', validators.String()),
-        ('info', validators.Ref('Info')),
-        ('servers', validators.Array(items=validators.Ref('Server'))),
-        ('paths', validators.Ref('Paths')),
-        ('components', validators.Ref('Components')),
-        ('security', validators.Ref('SecurityRequirement')),
-        ('tags', validators.Array(items=validators.Ref('Tag'))),
-        ('externalDocs', validators.Ref('ExternalDocumentation'))
+        ("openapi", validators.String()),
+        ("info", validators.Ref("Info")),
+        ("servers", validators.Array(items=validators.Ref("Server"))),
+        ("paths", validators.Ref("Paths")),
+        ("components", validators.Ref("Components")),
+        ("security", validators.Ref("SecurityRequirement")),
+        ("tags", validators.Array(items=validators.Ref("Tag"))),
+        ("externalDocs", validators.Ref("ExternalDocumentation")),
     ],
-    required=['openapi', 'info'],
+    required=["openapi", "info"],
     definitions={
-        'Info': validators.Object(
+        "Info": validators.Object(
             properties=[
-                ('title', validators.String()),
-                ('description', validators.String(format='textarea')),
-                ('termsOfService', validators.String(format='url')),
-                ('contact', validators.Ref('Contact')),
-                ('license', validators.Ref('License')),
-                ('version', validators.String())
+                ("title", validators.String()),
+                ("description", validators.String(format="textarea")),
+                ("termsOfService", validators.String(format="url")),
+                ("contact", validators.Ref("Contact")),
+                ("license", validators.Ref("License")),
+                ("version", validators.String()),
             ],
-            required=['title', 'version']
+            required=["title", "version"],
         ),
-        'Contact': validators.Object(
+        "Contact": validators.Object(
             properties=[
-                ('name', validators.String()),
-                ('url', validators.String(format='url')),
-                ('email', validators.String(format='email'))
+                ("name", validators.String()),
+                ("url", validators.String(format="url")),
+                ("email", validators.String(format="email")),
             ]
         ),
-        'License': validators.Object(
+        "License": validators.Object(
             properties=[
-                ('name', validators.String()),
-                ('url', validators.String(format='url'))
+                ("name", validators.String()), ("url", validators.String(format="url"))
             ],
-            required=['name']
+            required=["name"],
         ),
-        'Server': validators.Object(
+        "Server": validators.Object(
             properties=[
-                ('url', validators.String()),
-                ('description', validators.String(format='textarea')),
-                ('variables', validators.Object(additional_properties=validators.Ref('ServerVariable')))
+                ("url", validators.String()),
+                ("description", validators.String(format="textarea")),
+                (
+                    "variables",
+                    validators.Object(
+                        additional_properties=validators.Ref("ServerVariable")
+                    ),
+                ),
             ],
-            required=['url']
+            required=["url"],
         ),
-        'ServerVariable': validators.Object(
+        "ServerVariable": validators.Object(
             properties=[
-                ('enum', validators.Array(items=validators.String())),
-                ('default', validators.String()),
-                ('description', validators.String(format='textarea'))
+                ("enum", validators.Array(items=validators.String())),
+                ("default", validators.String()),
+                ("description", validators.String(format="textarea")),
             ],
-            required=['default']
+            required=["default"],
         ),
-        'Paths': validators.Object(
+        "Paths": validators.Object(
             pattern_properties=[
-                ('^/', validators.Ref('Path'))  # TODO: Path | ReferenceObject
+                ("^/", validators.Ref("Path"))  # TODO: Path | ReferenceObject
             ]
         ),
-        'Path': validators.Object(
+        "Path": validators.Object(
             properties=[
-                ('summary', validators.String()),
-                ('description', validators.String(format='textarea')),
-                ('get', validators.Ref('Operation')),
-                ('put', validators.Ref('Operation')),
-                ('post', validators.Ref('Operation')),
-                ('delete', validators.Ref('Operation')),
-                ('options', validators.Ref('Operation')),
-                ('head', validators.Ref('Operation')),
-                ('patch', validators.Ref('Operation')),
-                ('trace', validators.Ref('Operation')),
-                ('servers', validators.Array(items=validators.Ref('Server'))),
-                ('parameters', validators.Array(items=validators.Ref('Parameter')))  # TODO: | ReferenceObject
+                ("summary", validators.String()),
+                ("description", validators.String(format="textarea")),
+                ("get", validators.Ref("Operation")),
+                ("put", validators.Ref("Operation")),
+                ("post", validators.Ref("Operation")),
+                ("delete", validators.Ref("Operation")),
+                ("options", validators.Ref("Operation")),
+                ("head", validators.Ref("Operation")),
+                ("patch", validators.Ref("Operation")),
+                ("trace", validators.Ref("Operation")),
+                ("servers", validators.Array(items=validators.Ref("Server"))),
+                (
+                    "parameters", validators.Array(items=validators.Ref("Parameter"))
+                ),  # TODO: | ReferenceObject
             ]
         ),
-        'Operation': validators.Object(
+        "Operation": validators.Object(
             properties=[
-                ('tags', validators.Array(items=validators.String())),
-                ('summary', validators.String()),
-                ('description', validators.String(format='textarea')),
-                ('externalDocs', validators.Ref('ExternalDocumentation')),
-                ('operationId', validators.String()),
-                ('parameters', validators.Array(items=validators.Ref('Parameter'))),  # TODO: | ReferenceObject
-                ('requestBody', validators.Ref('RequestBody')),  # TODO: RequestBody | ReferenceObject
+                ("tags", validators.Array(items=validators.String())),
+                ("summary", validators.String()),
+                ("description", validators.String(format="textarea")),
+                ("externalDocs", validators.Ref("ExternalDocumentation")),
+                ("operationId", validators.String()),
+                (
+                    "parameters", validators.Array(items=validators.Ref("Parameter"))
+                ),  # TODO: | ReferenceObject
+                (
+                    "requestBody", validators.Ref("RequestBody")
+                ),  # TODO: RequestBody | ReferenceObject
                 # TODO: 'responses'
                 # TODO: 'callbacks'
-                ('deprecated', validators.Boolean()),
-                ('security', validators.Array(validators.Ref('SecurityRequirement'))),
-                ('servers', validators.Array(items=validators.Ref('Server')))
+                ("deprecated", validators.Boolean()),
+                ("security", validators.Array(validators.Ref("SecurityRequirement"))),
+                ("servers", validators.Array(items=validators.Ref("Server"))),
             ]
         ),
-        'ExternalDocumentation': validators.Object(
+        "ExternalDocumentation": validators.Object(
             properties=[
-                ('description', validators.String(format='textarea')),
-                ('url', validators.String(format='url'))
+                ("description", validators.String(format="textarea")),
+                ("url", validators.String(format="url")),
             ],
-            required=['url']
+            required=["url"],
         ),
-        'Parameter': validators.Object(
+        "Parameter": validators.Object(
             properties=[
-                ('name', validators.String()),
-                ('in', validators.String(enum=['query', 'header', 'path', 'cookie'])),
-                ('description', validators.String(format='textarea')),
-                ('required', validators.Boolean()),
-                ('deprecated', validators.Boolean()),
-                ('allowEmptyValue', validators.Boolean()),
-                ('schema', JSON_SCHEMA | SCHEMA_REF),
-                ('example', validators.Any())
+                ("name", validators.String()),
+                ("in", validators.String(enum=["query", "header", "path", "cookie"])),
+                ("description", validators.String(format="textarea")),
+                ("required", validators.Boolean()),
+                ("deprecated", validators.Boolean()),
+                ("allowEmptyValue", validators.Boolean()),
+                ("schema", JSON_SCHEMA | SCHEMA_REF),
+                ("example", validators.Any())
                 # TODO: Other fields
             ],
-            required=['name', 'in']
+            required=["name", "in"],
         ),
-        'RequestBody': validators.Object(
+        "RequestBody": validators.Object(
             properties=[
-                ('description', validators.String()),
-                ('content', validators.Object(additional_properties=validators.Ref('MediaType'))),
-                ('required', validators.Boolean())
+                ("description", validators.String()),
+                (
+                    "content",
+                    validators.Object(
+                        additional_properties=validators.Ref("MediaType")
+                    ),
+                ),
+                ("required", validators.Boolean()),
             ]
         ),
-        'MediaType': validators.Object(
+        "MediaType": validators.Object(
             properties=[
-                ('schema', JSON_SCHEMA | SCHEMA_REF),
-                ('example', validators.Any())
+                ("schema", JSON_SCHEMA | SCHEMA_REF),
+                ("example", validators.Any())
                 # TODO 'examples', 'encoding'
             ]
         ),
-        'Components': validators.Object(
+        "Components": validators.Object(
             properties=[
-                ('schemas', validators.Object(additional_properties=JSON_SCHEMA)),
+                ("schemas", validators.Object(additional_properties=JSON_SCHEMA))
             ]
         ),
-        'Tag': validators.Object(
+        "Tag": validators.Object(
             properties=[
-                ('name', validators.String()),
-                ('description', validators.String(format='textarea')),
-                ('externalDocs', validators.Ref('ExternalDocumentation'))
+                ("name", validators.String()),
+                ("description", validators.String(format="textarea")),
+                ("externalDocs", validators.Ref("ExternalDocumentation")),
             ],
-            required=['name']
+            required=["name"],
         ),
-        'SecurityRequirement': validators.Object(
+        "SecurityRequirement": validators.Object(
             additional_properties=validators.Array(items=validators.String())
-        )
-    }
+        ),
+    },
 )
 
 
-METHODS = [
-    'get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'
-]
+METHODS = ["get", "put", "post", "delete", "options", "head", "patch", "trace"]
 
 
 def lookup(value, keys, default=None):
@@ -173,6 +186,7 @@ def lookup(value, keys, default=None):
             value = value[key]
         except (KeyError, IndexError, TypeError):
             return default
+
     return value
 
 
@@ -183,42 +197,49 @@ def _relative_url(base_url, url):
     * If the have the same scheme and hostname, return the path & query params.
     * Otherwise return the full URL.
     """
-    base_prefix = '%s://%s' % urlparse(base_url or '')[0:2]
-    url_prefix = '%s://%s' % urlparse(url or '')[0:2]
-    if base_prefix == url_prefix and url_prefix != '://':
+    base_prefix = "%s://%s" % urlparse(base_url or "")[0:2]
+    url_prefix = "%s://%s" % urlparse(url or "")[0:2]
+    if base_prefix == url_prefix and url_prefix != "://":
         return url[len(url_prefix):]
+
     return url
 
 
 def _simple_slugify(text):
     text = text.lower()
-    text = re.sub(r'[^a-z0-9]+', '_', text)
-    text = re.sub(r'[_]+', '_', text)
-    return text.strip('_')
+    text = re.sub(r"[^a-z0-9]+", "_", text)
+    text = re.sub(r"[_]+", "_", text)
+    return text.strip("_")
 
 
 class OpenAPICodec(BaseCodec):
-    media_type = 'application/vnd.oai.openapi'
-    format = 'openapi'
+    media_type = "application/vnd.oai.openapi"
+    format = "openapi"
 
     def decode(self, bytestring, **options):
         try:
-            data = json.loads(bytestring.decode('utf-8'))
+            data = json.loads(bytestring.decode("utf-8"))
         except ValueError as exc:
-            raise ParseError('Malformed JSON. %s' % exc) from None
+            raise ParseError("Malformed JSON. %s" % exc) from None
 
         openapi = OPEN_API.validate(data)
-        title = lookup(openapi, ['info', 'title'])
-        description = lookup(openapi, ['info', 'description'])
-        version = lookup(openapi, ['info', 'version'])
-        base_url = lookup(openapi, ['servers', 0, 'url'])
+        title = lookup(openapi, ["info", "title"])
+        description = lookup(openapi, ["info", "description"])
+        version = lookup(openapi, ["info", "version"])
+        base_url = lookup(openapi, ["servers", 0, "url"])
         schema_definitions = self.get_schema_definitions(openapi)
         content = self.get_content(openapi, base_url, schema_definitions)
-        return Document(title=title, description=description, version=version, url=base_url, content=content)
+        return Document(
+            title=title,
+            description=description,
+            version=version,
+            url=base_url,
+            content=content,
+        )
 
     def get_schema_definitions(self, openapi):
         definitions = {}
-        schemas = lookup(openapi, ['components', 'schemas'], {})
+        schemas = lookup(openapi, ["components", "schemas"], {})
         for key, value in schemas.items():
             definitions[key] = JSONSchemaCodec().decode_from_data_structure(value)
         return definitions
@@ -230,14 +251,18 @@ class OpenAPICodec(BaseCodec):
         links_by_tag = dict_type()
         links = []
 
-        for path, path_info in openapi.get('paths', {}).items():
-            operations = {
-                key: path_info[key] for key in path_info
-                if key in METHODS
-            }
+        for path, path_info in openapi.get("paths", {}).items():
+            operations = {key: path_info[key] for key in path_info if key in METHODS}
             for operation, operation_info in operations.items():
-                tag = lookup(operation_info, ['tags', 0])
-                link = self.get_link(base_url, path, path_info, operation, operation_info, schema_definitions)
+                tag = lookup(operation_info, ["tags", 0])
+                link = self.get_link(
+                    base_url,
+                    path,
+                    path_info,
+                    operation,
+                    operation_info,
+                    schema_definitions,
+                )
                 if link is None:
                     continue
 
@@ -254,13 +279,15 @@ class OpenAPICodec(BaseCodec):
         ]
         return links + sections
 
-    def get_link(self, base_url, path, path_info, operation, operation_info, schema_definitions):
+    def get_link(
+        self, base_url, path, path_info, operation, operation_info, schema_definitions
+    ):
         """
         Return a single link in the document.
         """
-        name = operation_info.get('operationId')
-        title = operation_info.get('summary')
-        description = operation_info.get('description')
+        name = operation_info.get("operationId")
+        title = operation_info.get("summary")
+        description = operation_info.get("description")
 
         if name is None:
             name = _simple_slugify(title)
@@ -268,32 +295,33 @@ class OpenAPICodec(BaseCodec):
                 return None
 
         # Allow path info and operation info to override the base url.
-        base_url = lookup(path_info, ['servers', 0, 'url'], default=base_url)
-        base_url = lookup(operation_info, ['servers', 0, 'url'], default=base_url)
+        base_url = lookup(path_info, ["servers", 0, "url"], default=base_url)
+        base_url = lookup(operation_info, ["servers", 0, "url"], default=base_url)
 
         # Parameters are taken both from the path info, and from the operation.
-        parameters = path_info.get('parameters', [])
-        parameters += operation_info.get('parameters', [])
+        parameters = path_info.get("parameters", [])
+        parameters += operation_info.get("parameters", [])
 
         fields = [
-            self.get_field(parameter, schema_definitions)
-            for parameter in parameters
+            self.get_field(parameter, schema_definitions) for parameter in parameters
         ]
 
         # TODO: Handle media type generically here...
-        body_schema = lookup(operation_info, ['requestBody', 'content', 'application/json', 'schema'])
+        body_schema = lookup(
+            operation_info, ["requestBody", "content", "application/json", "schema"]
+        )
 
         encoding = None
         if body_schema:
-            encoding = 'application/json'
-            if '$ref' in body_schema:
-                ref = body_schema['$ref'][len('#/components/schemas/'):]
+            encoding = "application/json"
+            if "$ref" in body_schema:
+                ref = body_schema["$ref"][len("#/components/schemas/"):]
                 schema = schema_definitions.get(ref)
             else:
                 schema = JSONSchemaCodec().decode_from_data_structure(body_schema)
             if isinstance(schema, validators.Object):
                 for key, value in schema.properties.items():
-                    fields += [Field(name=key, location='form', schema=value)]
+                    fields += [Field(name=key, location="form", schema=value)]
 
         return Link(
             name=name,
@@ -302,23 +330,23 @@ class OpenAPICodec(BaseCodec):
             title=title,
             description=description,
             fields=fields,
-            encoding=encoding
+            encoding=encoding,
         )
 
     def get_field(self, parameter, schema_definitions):
         """
         Return a single field in a link.
         """
-        name = parameter.get('name')
-        location = parameter.get('in')
-        description = parameter.get('description')
-        required = parameter.get('required', False)
-        schema = parameter.get('schema')
-        example = parameter.get('example')
+        name = parameter.get("name")
+        location = parameter.get("in")
+        description = parameter.get("description")
+        required = parameter.get("required", False)
+        schema = parameter.get("schema")
+        example = parameter.get("example")
 
         if schema is not None:
-            if '$ref' in schema:
-                ref = schema['$ref'][len('#/components/schemas/'):]
+            if "$ref" in schema:
+                ref = schema["$ref"][len("#/components/schemas/"):]
                 schema = schema_definitions.get(ref)
             else:
                 schema = JSONSchemaCodec().decode_from_data_structure(schema)
@@ -329,37 +357,33 @@ class OpenAPICodec(BaseCodec):
             description=description,
             required=required,
             schema=schema,
-            example=example
+            example=example,
         )
 
     def encode(self, document, **options):
         schema_defs = {}
         paths = self.get_paths(document, schema_defs=schema_defs)
-        openapi = OPEN_API.validate({
-            'openapi': '3.0.0',
-            'info': {
-                'version': document.version,
-                'title': document.title,
-                'description': document.description
-            },
-            'servers': [{
-                'url': document.url
-            }],
-            'paths': paths
-        })
+        openapi = OPEN_API.validate(
+            {
+                "openapi": "3.0.0",
+                "info": {
+                    "version": document.version,
+                    "title": document.title,
+                    "description": document.description,
+                },
+                "servers": [{"url": document.url}],
+                "paths": paths,
+            }
+        )
 
         if schema_defs:
-            openapi['components'] = {'schemas': schema_defs}
+            openapi["components"] = {"schemas": schema_defs}
 
         if not document.url:
-            openapi.pop('servers')
+            openapi.pop("servers")
 
-        kwargs = {
-            'ensure_ascii': False,
-            'indent': 4,
-            'separators': (',', ': ')
-        }
-        return json.dumps(openapi, **kwargs).encode('utf-8')
+        kwargs = {"ensure_ascii": False, "indent": 4, "separators": (",", ": ")}
+        return json.dumps(openapi, **kwargs).encode("utf-8")
 
     def get_paths(self, document, schema_defs=None):
         paths = dict_type()
@@ -372,24 +396,24 @@ class OpenAPICodec(BaseCodec):
 
             if path not in paths:
                 paths[path] = {}
-            paths[path][method] = self.get_operation(link, operation_id, tag=tag, schema_defs=schema_defs)
+            paths[path][method] = self.get_operation(
+                link, operation_id, tag=tag, schema_defs=schema_defs
+            )
 
         return paths
 
     def get_operation(self, link, operation_id, tag=None, schema_defs=None):
-        operation = {
-            'operationId': operation_id
-        }
+        operation = {"operationId": operation_id}
         if link.title:
-            operation['summary'] = link.title
+            operation["summary"] = link.title
         if link.description:
-            operation['description'] = link.description
+            operation["description"] = link.description
         if tag:
-            operation['tags'] = [tag]
+            operation["tags"] = [tag]
         if link.get_path_fields() or link.get_query_fields():
-            operation['parameters'] = [
-                self.get_parameter(field, schema_defs) for field in
-                link.get_path_fields() + link.get_query_fields()
+            operation["parameters"] = [
+                self.get_parameter(field, schema_defs)
+                for field in link.get_path_fields() + link.get_query_fields()
             ]
         if link.get_body_field():
             schema = link.get_body_field().schema
@@ -397,33 +421,22 @@ class OpenAPICodec(BaseCodec):
                 content_info = {}
             else:
                 content_info = {
-                    'schema': JSONSchemaCodec().encode_to_data_structure(
-                        schema,
-                        schema_defs,
-                        '#/components/schemas/'
+                    "schema": JSONSchemaCodec().encode_to_data_structure(
+                        schema, schema_defs, "#/components/schemas/"
                     )
                 }
 
-            operation['responseBody'] = {
-                'content': {
-                    link.encoding: content_info
-                }
-            }
+            operation["responseBody"] = {"content": {link.encoding: content_info}}
         return operation
 
     def get_parameter(self, field, schema_defs=None):
-        parameter = {
-            'name': field.name,
-            'in': field.location
-        }
+        parameter = {"name": field.name, "in": field.location}
         if field.required:
-            parameter['required'] = True
+            parameter["required"] = True
         if field.description:
-            parameter['description'] = field.description
+            parameter["description"] = field.description
         if field.schema:
-            parameter['schema'] = JSONSchemaCodec().encode_to_data_structure(
-                field.schema,
-                schema_defs,
-                '#/components/schemas/'
+            parameter["schema"] = JSONSchemaCodec().encode_to_data_structure(
+                field.schema, schema_defs, "#/components/schemas/"
             )
         return parameter

--- a/apistar/codecs/text.py
+++ b/apistar/codecs/text.py
@@ -2,8 +2,8 @@ from apistar.codecs.base import BaseCodec
 
 
 class TextCodec(BaseCodec):
-    media_type = 'text/*'
-    format = 'text'
+    media_type = "text/*"
+    format = "text"
 
     def decode(self, bytestring, **options):
-        return bytestring.decode('utf-8')
+        return bytestring.decode("utf-8")

--- a/apistar/compat.py
+++ b/apistar/compat.py
@@ -41,6 +41,7 @@ try:
         def __str__(self):
             return self.__repr__()
 
+
 except ImportError:
     # On some platforms (eg GAE) the private _TemporaryFileWrapper may not be
     # available, just use the standard `NamedTemporaryFile` function

--- a/apistar/conneg.py
+++ b/apistar/conneg.py
@@ -9,9 +9,9 @@ def negotiate_content_type(codecs, content_type=None):
     if content_type is None:
         return codecs[0]
 
-    content_type = content_type.split(';')[0].strip().lower()
-    main_type = content_type.split('/')[0] + '/*'
-    wildcard_type = '*/*'
+    content_type = content_type.split(";")[0].strip().lower()
+    main_type = content_type.split("/")[0] + "/*"
+    wildcard_type = "*/*"
 
     for codec in codecs:
         if codec.media_type in (content_type, main_type, wildcard_type):

--- a/apistar/document.py
+++ b/apistar/document.py
@@ -4,16 +4,19 @@ import typing
 
 from apistar.validators import Validator
 
-LinkInfo = collections.namedtuple('LinkInfo', ['link', 'name', 'sections'])
+LinkInfo = collections.namedtuple("LinkInfo", ["link", "name", "sections"])
 
 
 class Document:
-    def __init__(self,
-                 content: typing.Sequence[typing.Union['Section', 'Link']]=None,
-                 url: str='',
-                 title: str='',
-                 description: str='',
-                 version: str=''):
+
+    def __init__(
+        self,
+        content: typing.Sequence[typing.Union["Section", "Link"]] = None,
+        url: str = "",
+        title: str = "",
+        description: str = "",
+        version: str = "",
+    ):
         content = [] if (content is None) else list(content)
 
         # Ensure all names within a document are unique.
@@ -53,11 +56,14 @@ class Document:
 
 
 class Section:
-    def __init__(self,
-                 name: str,
-                 content: typing.Sequence[typing.Union['Section', 'Link']]=None,
-                 title: str='',
-                 description: str=''):
+
+    def __init__(
+        self,
+        name: str,
+        content: typing.Sequence[typing.Union["Section", "Link"]] = None,
+        title: str = "",
+        description: str = "",
+    ):
         content = [] if (content is None) else list(content)
 
         # Ensure all names within a section are unique.
@@ -89,7 +95,7 @@ class Section:
         sections = previous_sections + (self,)
         for item in self.content:
             if isinstance(item, Link):
-                name = ':'.join([section.name for section in sections] + [item.name])
+                name = ":".join([section.name for section in sections] + [item.name])
                 link_info = LinkInfo(link=item, name=name, sections=sections)
                 link_info_list.append(link_info)
             else:
@@ -101,31 +107,29 @@ class Link:
     """
     Links represent the actions that a client may perform.
     """
-    def __init__(self,
-                 url: str,
-                 method: str,
-                 handler: typing.Callable=None,
-                 name: str='',
-                 encoding: str='',
-                 title: str='',
-                 description: str='',
-                 fields: typing.Sequence['Field']=None):
+
+    def __init__(
+        self,
+        url: str,
+        method: str,
+        handler: typing.Callable = None,
+        name: str = "",
+        encoding: str = "",
+        title: str = "",
+        description: str = "",
+        fields: typing.Sequence["Field"] = None,
+    ):
         method = method.upper()
         fields = [] if (fields is None) else list(fields)
 
-        url_path_names = set([
-            item.strip('{}').lstrip('+') for item in re.findall('{[^}]*}', url)
-        ])
-        path_fields = [
-            field for field in fields if field.location == 'path'
-        ]
-        body_fields = [
-            field for field in fields if field.location == 'body'
-        ]
+        url_path_names = set(
+            [item.strip("{}").lstrip("+") for item in re.findall("{[^}]*}", url)]
+        )
+        path_fields = [field for field in fields if field.location == "path"]
+        body_fields = [field for field in fields if field.location == "body"]
 
         assert method in (
-            'GET', 'POST', 'PUT', 'PATCH',
-            'DELETE', 'OPTIONS', 'HEAD', 'TRACE'
+            "GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD", "TRACE"
         )
         assert len(body_fields) < 2
         if body_fields:
@@ -137,7 +141,7 @@ class Link:
         # a corresponding path field.
         for path_name in url_path_names:
             if path_name not in [field.name for field in path_fields]:
-                fields += [Field(name=path_name, location='path', required=True)]
+                fields += [Field(name=path_name, location="path", required=True)]
 
         self.url = url
         self.method = method
@@ -149,31 +153,35 @@ class Link:
         self.fields = fields
 
     def get_path_fields(self):
-        return [field for field in self.fields if field.location == 'path']
+        return [field for field in self.fields if field.location == "path"]
 
     def get_query_fields(self):
-        return [field for field in self.fields if field.location == 'query']
+        return [field for field in self.fields if field.location == "query"]
 
     def get_body_field(self):
         for field in self.fields:
-            if field.location == 'body':
+            if field.location == "body":
                 return field
+
         return None
 
 
 class Field:
-    def __init__(self,
-                 name: str,
-                 location: str,
-                 title: str='',
-                 description: str='',
-                 required: bool=None,
-                 schema: Validator=None,
-                 example: typing.Any=None):
-        assert location in ('path', 'query', 'body')
+
+    def __init__(
+        self,
+        name: str,
+        location: str,
+        title: str = "",
+        description: str = "",
+        required: bool = None,
+        schema: Validator = None,
+        example: typing.Any = None,
+    ):
+        assert location in ("path", "query", "body")
         if required is None:
-            required = True if location in ('path', 'body') else False
-        if location == 'path':
+            required = True if location in ("path", "body") else False
+        if location == "path":
             assert required, "May not set 'required=False' on path fields."
 
         self.name = name

--- a/apistar/exceptions.py
+++ b/apistar/exceptions.py
@@ -2,6 +2,7 @@ from typing import Union
 
 
 class ValidationError(Exception):
+
     def __init__(self, detail):
         assert isinstance(detail, (str, dict))
         self.detail = detail
@@ -26,6 +27,7 @@ class ErrorResponse(Exception):
     """
     Raised when a client request results in an error response being returned.
     """
+
     def __init__(self, title, content):
         self.title = title
         self.content = content
@@ -48,15 +50,18 @@ class ConfigurationError(Exception):
 
 # HTTP exceptions
 
+
 class HTTPException(Exception):
     default_status_code = None  # type: int
     default_detail = None  # type: str
 
-    def __init__(self,
-                 detail: Union[str, dict]=None,
-                 status_code: int=None) -> None:
+    def __init__(
+        self, detail: Union[str, dict] = None, status_code: int = None
+    ) -> None:
         self.detail = self.default_detail if (detail is None) else detail
-        self.status_code = self.default_status_code if (status_code is None) else status_code
+        self.status_code = self.default_status_code if (
+            status_code is None
+        ) else status_code
         assert self.detail is not None, '"detail" is required.'
         assert self.status_code is not None, '"status_code" is required.'
 
@@ -66,44 +71,43 @@ class HTTPException(Exception):
 
 class Found(HTTPException):
     default_status_code = 302
-    default_detail = 'Found'
+    default_detail = "Found"
 
-    def __init__(self,
-                 location: str,
-                 detail: Union[str, dict]=None,
-                 status_code: int=None) -> None:
+    def __init__(
+        self, location: str, detail: Union[str, dict] = None, status_code: int = None
+    ) -> None:
         self.location = location
         super().__init__(detail, status_code)
 
     def get_headers(self):
-        return {'Location': self.location}
+        return {"Location": self.location}
 
 
 class BadRequest(HTTPException):
     default_status_code = 400
-    default_detail = 'Bad request'
+    default_detail = "Bad request"
 
 
 class Forbidden(HTTPException):
     default_status_code = 403
-    default_detail = 'Forbidden'
+    default_detail = "Forbidden"
 
 
 class NotFound(HTTPException):
     default_status_code = 404
-    default_detail = 'Not found'
+    default_detail = "Not found"
 
 
 class MethodNotAllowed(HTTPException):
     default_status_code = 405
-    default_detail = 'Method not allowed'
+    default_detail = "Method not allowed"
 
 
 class NotAcceptable(HTTPException):
     default_status_code = 406
-    default_detail = 'Could not satisfy the request Accept header'
+    default_detail = "Could not satisfy the request Accept header"
 
 
 class UnsupportedMediaType(HTTPException):
     default_status_code = 415
-    default_detail = 'Unsupported Content-Type header in request'
+    default_detail = "Unsupported Content-Type header in request"

--- a/apistar/formats.py
+++ b/apistar/formats.py
@@ -3,24 +3,23 @@ import re
 
 from apistar.exceptions import ValidationError
 
-DATE_REGEX = re.compile(
-    r'(?P<year>\d{4})-(?P<month>\d{1,2})-(?P<day>\d{1,2})$'
-)
+DATE_REGEX = re.compile(r"(?P<year>\d{4})-(?P<month>\d{1,2})-(?P<day>\d{1,2})$")
 
 TIME_REGEX = re.compile(
-    r'(?P<hour>\d{1,2}):(?P<minute>\d{1,2})'
-    r'(?::(?P<second>\d{1,2})(?:\.(?P<microsecond>\d{1,6})\d{0,6})?)?'
+    r"(?P<hour>\d{1,2}):(?P<minute>\d{1,2})"
+    r"(?::(?P<second>\d{1,2})(?:\.(?P<microsecond>\d{1,6})\d{0,6})?)?"
 )
 
 DATETIME_REGEX = re.compile(
-    r'(?P<year>\d{4})-(?P<month>\d{1,2})-(?P<day>\d{1,2})'
-    r'[T ](?P<hour>\d{1,2}):(?P<minute>\d{1,2})'
-    r'(?::(?P<second>\d{1,2})(?:\.(?P<microsecond>\d{1,6})\d{0,6})?)?'
-    r'(?P<tzinfo>Z|[+-]\d{2}(?::?\d{2})?)?$'
+    r"(?P<year>\d{4})-(?P<month>\d{1,2})-(?P<day>\d{1,2})"
+    r"[T ](?P<hour>\d{1,2}):(?P<minute>\d{1,2})"
+    r"(?::(?P<second>\d{1,2})(?:\.(?P<microsecond>\d{1,6})\d{0,6})?)?"
+    r"(?P<tzinfo>Z|[+-]\d{2}(?::?\d{2})?)?$"
 )
 
 
 class BaseFormat:
+
     def is_native_type(self, value):
         raise NotImplementedError()
 
@@ -32,13 +31,14 @@ class BaseFormat:
 
 
 class DateFormat(BaseFormat):
+
     def is_native_type(self, value):
         return isinstance(value, datetime.date)
 
     def validate(self, value):
         match = DATE_REGEX.match(value)
         if not match:
-            raise ValidationError('Must be a valid date.')
+            raise ValidationError("Must be a valid date.")
 
         kwargs = {k: int(v) for k, v in match.groupdict().items()}
         return datetime.date(**kwargs)
@@ -48,16 +48,19 @@ class DateFormat(BaseFormat):
 
 
 class TimeFormat(BaseFormat):
+
     def is_native_type(self, value):
         return isinstance(value, datetime.time)
 
     def validate(self, value):
         match = TIME_REGEX.match(value)
         if not match:
-            raise ValidationError('Must be a valid time.')
+            raise ValidationError("Must be a valid time.")
 
         kwargs = match.groupdict()
-        kwargs['microsecond'] = kwargs['microsecond'] and kwargs['microsecond'].ljust(6, '0')
+        kwargs["microsecond"] = kwargs["microsecond"] and kwargs["microsecond"].ljust(
+            6, "0"
+        )
         kwargs = {k: int(v) for k, v in kwargs.items() if v is not None}
         return datetime.time(**kwargs)
 
@@ -66,32 +69,35 @@ class TimeFormat(BaseFormat):
 
 
 class DateTimeFormat(BaseFormat):
+
     def is_native_type(self, value):
         return isinstance(value, datetime.datetime)
 
     def validate(self, value):
         match = DATETIME_REGEX.match(value)
         if not match:
-            raise ValidationError('Must be a valid datetime.')
+            raise ValidationError("Must be a valid datetime.")
 
         kwargs = match.groupdict()
-        kwargs['microsecond'] = kwargs['microsecond'] and kwargs['microsecond'].ljust(6, '0')
-        tzinfo = kwargs.pop('tzinfo')
-        if tzinfo == 'Z':
+        kwargs["microsecond"] = kwargs["microsecond"] and kwargs["microsecond"].ljust(
+            6, "0"
+        )
+        tzinfo = kwargs.pop("tzinfo")
+        if tzinfo == "Z":
             tzinfo = datetime.timezone.utc
         elif tzinfo is not None:
             offset_mins = int(tzinfo[-2:]) if len(tzinfo) > 3 else 0
             offset_hours = int(tzinfo[1:3])
             delta = datetime.timedelta(hours=offset_hours, minutes=offset_mins)
-            if tzinfo[0] == '-':
+            if tzinfo[0] == "-":
                 delta = -delta
             tzinfo = datetime.timezone(delta)
         kwargs = {k: int(v) for k, v in kwargs.items() if v is not None}
-        kwargs['tzinfo'] = tzinfo
+        kwargs["tzinfo"] = tzinfo
         return datetime.datetime(**kwargs)
 
     def to_string(self, value):
         value = value.isoformat()
-        if value.endswith('+00:00'):
-            value = value[:-6] + 'Z'
+        if value.endswith("+00:00"):
+            value = value[:-6] + "Z"
         return value

--- a/apistar/http.py
+++ b/apistar/http.py
@@ -4,18 +4,18 @@ from urllib.parse import urlparse
 
 from apistar import types
 
-Method = typing.NewType('Method', str)
-Scheme = typing.NewType('Scheme', str)
-Host = typing.NewType('Host', str)
-Port = typing.NewType('Port', int)
-Path = typing.NewType('Path', str)
-QueryString = typing.NewType('QueryString', str)
-QueryParam = typing.NewType('QueryParam', str)
-Header = typing.NewType('Header', str)
-Body = typing.NewType('Body', bytes)
-PathParams = typing.NewType('PathParams', dict)
-PathParam = typing.NewType('PathParam', str)
-RequestData = typing.TypeVar('RequestData')
+Method = typing.NewType("Method", str)
+Scheme = typing.NewType("Scheme", str)
+Host = typing.NewType("Host", str)
+Port = typing.NewType("Port", int)
+Path = typing.NewType("Path", str)
+QueryString = typing.NewType("QueryString", str)
+QueryParam = typing.NewType("QueryParam", str)
+Header = typing.NewType("Header", str)
+Body = typing.NewType("Body", bytes)
+PathParams = typing.NewType("PathParams", dict)
+PathParam = typing.NewType("PathParam", str)
+RequestData = typing.TypeVar("RequestData")
 
 
 class URL(str):
@@ -26,7 +26,7 @@ class URL(str):
 
     @property
     def components(self):
-        if not hasattr(self, '_components'):
+        if not hasattr(self, "_components"):
             self._components = urlparse(self)
         return self._components
 
@@ -41,10 +41,10 @@ class QueryParams(typing.Mapping[str, str]):
     An immutable multidict.
     """
 
-    def __init__(self, value: typing.Union[StrMapping, StrPairs]=None) -> None:
+    def __init__(self, value: typing.Union[StrMapping, StrPairs] = None) -> None:
         if value is None:
             value = []
-        if hasattr(value, 'items'):
+        if hasattr(value, "items"):
             items = list(value.items())
         else:
             items = list(value)
@@ -52,10 +52,7 @@ class QueryParams(typing.Mapping[str, str]):
         self._list = items
 
     def get_list(self, key: str) -> typing.List[str]:
-        return [
-            item_value for item_key, item_value in self._list
-            if item_key == key
-        ]
+        return [item_value for item_key, item_value in self._list if item_key == key]
 
     def keys(self):
         return [key for key, value in self._list]
@@ -69,6 +66,7 @@ class QueryParams(typing.Mapping[str, str]):
     def get(self, key, default=None):
         if key in self._dict:
             return self._dict[key]
+
         else:
             return default
 
@@ -90,7 +88,7 @@ class QueryParams(typing.Mapping[str, str]):
         return sorted(self._list) == sorted(other._list)
 
     def __repr__(self):
-        return 'QueryParams(%s)' % repr(self._list)
+        return "QueryParams(%s)" % repr(self._list)
 
 
 class Headers(typing.Mapping[str, str]):
@@ -98,10 +96,10 @@ class Headers(typing.Mapping[str, str]):
     An immutable, case-insensitive multidict.
     """
 
-    def __init__(self, value: typing.Union[StrMapping, StrPairs]=None) -> None:
+    def __init__(self, value: typing.Union[StrMapping, StrPairs] = None) -> None:
         if value is None:
             value = []
-        if hasattr(value, 'items'):
+        if hasattr(value, "items"):
             items = [(k.lower(), str(v)) for k, v in list(value.items())]
         else:
             items = [(k.lower(), str(v)) for k, v in list(value)]
@@ -111,8 +109,7 @@ class Headers(typing.Mapping[str, str]):
     def get_list(self, key: str) -> typing.List[str]:
         key_lower = key.lower()
         return [
-            item_value for item_key, item_value in self._list
-            if item_key == key_lower
+            item_value for item_key, item_value in self._list if item_key == key_lower
         ]
 
     def keys(self):
@@ -124,10 +121,11 @@ class Headers(typing.Mapping[str, str]):
     def items(self):
         return list(self._list)
 
-    def get(self, key: str, default: str=None):
+    def get(self, key: str, default: str = None):
         key = key.lower()
         if key in self._dict:
             return self._dict[key]
+
         else:
             return default
 
@@ -149,10 +147,11 @@ class Headers(typing.Mapping[str, str]):
         return sorted(self._list) == sorted(other._list)
 
     def __repr__(self):
-        return '%s(%s)' % (self.__class__.__name__, repr(self._list))
+        return "%s(%s)" % (self.__class__.__name__, repr(self._list))
 
 
 class MutableHeaders(Headers):
+
     def __setitem__(self, key: str, value: str):
         key = key.lower()
         value = str(value)
@@ -169,25 +168,26 @@ class MutableHeaders(Headers):
 
 
 class Request:
-    def __init__(self,
-                 method: Method,
-                 url: URL,
-                 headers: Headers=None,
-                 body: Body=None) -> None:
+
+    def __init__(
+        self, method: Method, url: URL, headers: Headers = None, body: Body = None
+    ) -> None:
         self.method = method
         self.url = url
         self.headers = Headers() if (headers is None) else headers
-        self.body = Body(b'') if (body is None) else body
+        self.body = Body(b"") if (body is None) else body
 
 
 class Response:
     media_type = None
-    charset = 'utf-8'
+    charset = "utf-8"
 
-    def __init__(self,
-                 content: typing.Any,
-                 status_code: int=200,
-                 headers: typing.Union[StrMapping, StrPairs]=None) -> None:
+    def __init__(
+        self,
+        content: typing.Any,
+        status_code: int = 200,
+        headers: typing.Union[StrMapping, StrPairs] = None,
+    ) -> None:
         self.content = self.render(content)
         self.status_code = status_code
         self.headers = MutableHeaders(headers)
@@ -196,48 +196,50 @@ class Response:
     def render(self, content: typing.Any) -> bytes:
         if isinstance(content, bytes):
             return content
+
         elif isinstance(content, str) and self.charset is not None:
             return content.encode(self.charset)
 
         valid_types = "bytes" if self.charset is None else "string or bytes"
         raise RuntimeError(
-            "%s content must be %s. Got %s." %
-            (self.__class__.__name__, valid_types, type(content).__name__)
+            "%s content must be %s. Got %s."
+            % (self.__class__.__name__, valid_types, type(content).__name__)
         )
 
     def set_default_headers(self):
-        if 'Content-Length' not in self.headers:
-            self.headers['Content-Length'] = str(len(self.content))
+        if "Content-Length" not in self.headers:
+            self.headers["Content-Length"] = str(len(self.content))
 
-        if 'Content-Type' not in self.headers and self.media_type is not None:
+        if "Content-Type" not in self.headers and self.media_type is not None:
             content_type = self.media_type
             if self.charset is not None:
-                content_type += '; charset=%s' % self.charset
-            self.headers['Content-Type'] = content_type
+                content_type += "; charset=%s" % self.charset
+            self.headers["Content-Type"] = content_type
 
 
 class HTMLResponse(Response):
-    media_type = 'text/html'
-    charset = 'utf-8'
+    media_type = "text/html"
+    charset = "utf-8"
 
 
 class JSONResponse(Response):
-    media_type = 'application/json'
+    media_type = "application/json"
     charset = None
     options = {
-        'ensure_ascii': False,
-        'allow_nan': False,
-        'indent': None,
-        'separators': (',', ':'),
+        "ensure_ascii": False,
+        "allow_nan": False,
+        "indent": None,
+        "separators": (",", ":"),
     }
 
     def render(self, content: typing.Any) -> bytes:
-        options = {'default': self.default}
+        options = {"default": self.default}
         options.update(self.options)
-        return json.dumps(content, **options).encode('utf-8')
+        return json.dumps(content, **options).encode("utf-8")
 
     def default(self, obj: typing.Any) -> typing.Any:
         if isinstance(obj, types.Type):
             return dict(obj)
+
         error = "Object of type '%s' is not JSON serializable."
         return TypeError(error % type(obj).__name_)

--- a/apistar/server/__init__.py
+++ b/apistar/server/__init__.py
@@ -2,4 +2,4 @@ from apistar.server.app import App, ASyncApp
 from apistar.server.components import Component
 from apistar.server.core import Include, Route
 
-__all__ = ['App', 'ASyncApp', 'Component', 'Route', 'Include']
+__all__ = ["App", "ASyncApp", "Component", "Route", "Include"]

--- a/apistar/server/adapters.py
+++ b/apistar/server/adapters.py
@@ -10,6 +10,7 @@ class ASGItoWSGIAdapter(object):
     We want this so that we can use the Werkzeug development server and
     debugger together with an ASGI application.
     """
+
     def __init__(self, asgi):
         self.asgi = asgi
         self.loop = asyncio.get_event_loop()
@@ -20,22 +21,19 @@ class ASGItoWSGIAdapter(object):
         asgi_coroutine = self.asgi(message)
 
         async def send(message):
-            if message['type'] == 'http.response.start':
-                status = RESPONSE_STATUS_TEXT[message['status']]
+            if message["type"] == "http.response.start":
+                status = RESPONSE_STATUS_TEXT[message["status"]]
                 headers = [
-                    [key.decode('latin-1'), value.decode('latin-1')]
-                    for key, value in message['headers']
+                    [key.decode("latin-1"), value.decode("latin-1")]
+                    for key, value in message["headers"]
                 ]
                 exc_info = None
                 start_response(status, headers, exc_info)
-            elif message['type'] == 'http.response.body':
-                return_bytes.append(message.get('body', b''))
+            elif message["type"] == "http.response.body":
+                return_bytes.append(message.get("body", b""))
 
         async def recieve():
-            return {
-                'type': 'http.request',
-                'body': environ['wsgi.input'].read()
-            }
+            return {"type": "http.request", "body": environ["wsgi.input"].read()}
 
         self.loop.run_until_complete(asgi_coroutine(recieve, send))
         return return_bytes
@@ -45,30 +43,34 @@ class ASGItoWSGIAdapter(object):
         WSGI environ -> ASGI message
         """
         message = {
-            'method': environ['REQUEST_METHOD'].upper(),
-            'root_path': environ.get('SCRIPT_NAME', ''),
-            'path': environ.get('PATH_INFO', ''),
-            'query_string': environ.get('QUERY_STRING', '').encode('latin-1'),
-            'http_version': environ.get('SERVER_PROTOCOL', 'http/1.0').split('/', 1)[-1],
-            'scheme': environ.get('wsgi.url_scheme', 'http'),
+            "method": environ["REQUEST_METHOD"].upper(),
+            "root_path": environ.get("SCRIPT_NAME", ""),
+            "path": environ.get("PATH_INFO", ""),
+            "query_string": environ.get("QUERY_STRING", "").encode("latin-1"),
+            "http_version": environ.get("SERVER_PROTOCOL", "http/1.0").split("/", 1)[
+                -1
+            ],
+            "scheme": environ.get("wsgi.url_scheme", "http"),
         }
 
-        if 'REMOTE_ADDR' in environ and 'REMOTE_PORT' in environ:
-            message['client'] = [environ['REMOTE_ADDR'], int(environ['REMOTE_PORT'])]
-        if 'SERVER_NAME' in environ and 'SERVER_PORT' in environ:
-            message['server'] = [environ['SERVER_NAME'], int(environ['SERVER_PORT'])]
+        if "REMOTE_ADDR" in environ and "REMOTE_PORT" in environ:
+            message["client"] = [environ["REMOTE_ADDR"], int(environ["REMOTE_PORT"])]
+        if "SERVER_NAME" in environ and "SERVER_PORT" in environ:
+            message["server"] = [environ["SERVER_NAME"], int(environ["SERVER_PORT"])]
 
         headers = []
-        if environ.get('CONTENT_TYPE'):
-            headers.append([b'content-type', environ['CONTENT_TYPE'].encode('latin-1')])
-        if environ.get('CONTENT_LENGTH'):
-            headers.append([b'content-length', environ['CONTENT_LENGTH'].encode('latin-1')])
+        if environ.get("CONTENT_TYPE"):
+            headers.append([b"content-type", environ["CONTENT_TYPE"].encode("latin-1")])
+        if environ.get("CONTENT_LENGTH"):
+            headers.append(
+                [b"content-length", environ["CONTENT_LENGTH"].encode("latin-1")]
+            )
         for key, val in environ.items():
-            if key.startswith('HTTP_'):
-                key_bytes = key[5:].replace('_', '-').lower().encode('latin-1')
+            if key.startswith("HTTP_"):
+                key_bytes = key[5:].replace("_", "-").lower().encode("latin-1")
                 val_bytes = val.encode()
                 headers.append([key_bytes, val_bytes])
 
-        message['headers'] = headers
+        message["headers"] = headers
 
         return message

--- a/apistar/server/app.py
+++ b/apistar/server/app.py
@@ -3,7 +3,12 @@ import werkzeug
 from apistar import exceptions
 from apistar.http import HTMLResponse, JSONResponse, PathParams, Response
 from apistar.server.adapters import ASGItoWSGIAdapter
-from apistar.server.asgi import ASGI_COMPONENTS, ASGIReceive, ASGIScope, ASGISend
+from apistar.server.asgi import (
+    ASGI_COMPONENTS,
+    ASGIReceive,
+    ASGIScope,
+    ASGISend
+)
 from apistar.server.components import Component
 from apistar.server.core import Route, generate_document
 from apistar.server.injector import ASyncInjector, Injector
@@ -12,7 +17,10 @@ from apistar.server.staticfiles import ASyncStaticFiles, StaticFiles
 from apistar.server.templates import Templates
 from apistar.server.validation import VALIDATION_COMPONENTS
 from apistar.server.wsgi import (
-    RESPONSE_STATUS_TEXT, WSGI_COMPONENTS, WSGIEnviron, WSGIStartResponse
+    RESPONSE_STATUS_TEXT,
+    WSGI_COMPONENTS,
+    WSGIEnviron,
+    WSGIStartResponse
 )
 
 

--- a/apistar/server/asgi.py
+++ b/apistar/server/asgi.py
@@ -5,124 +5,125 @@ from urllib.parse import parse_qsl
 from apistar import http
 from apistar.server.components import Component
 
-ASGIScope = typing.NewType('ASGIScope', dict)
-ASGIReceive = typing.NewType('ASGIReceive', typing.Callable)
-ASGISend = typing.NewType('ASGISend', typing.Callable)
+ASGIScope = typing.NewType("ASGIScope", dict)
+ASGIReceive = typing.NewType("ASGIReceive", typing.Callable)
+ASGISend = typing.NewType("ASGISend", typing.Callable)
 
 
 class MethodComponent(Component):
-    def resolve(self,
-                scope: ASGIScope) -> http.Method:
-        return http.Method(scope['method'])
+
+    def resolve(self, scope: ASGIScope) -> http.Method:
+        return http.Method(scope["method"])
 
 
 class URLComponent(Component):
-    def resolve(self,
-                scope: ASGIScope) -> http.URL:
-        scheme = scope['scheme']
-        host, port = scope['server']
-        path = scope['path']
 
-        if (scheme == 'http' and port != 80) or (scheme == 'https' and port != 443):
-            url = '%s://%s:%s%s' % (scheme, host, port, path)
+    def resolve(self, scope: ASGIScope) -> http.URL:
+        scheme = scope["scheme"]
+        host, port = scope["server"]
+        path = scope["path"]
+
+        if (scheme == "http" and port != 80) or (scheme == "https" and port != 443):
+            url = "%s://%s:%s%s" % (scheme, host, port, path)
         else:
-            url = '%s://%s%s' % (scheme, host, path)
+            url = "%s://%s%s" % (scheme, host, path)
 
-        query_string = scope['query_string']
+        query_string = scope["query_string"]
         if query_string:
-            url += '?' + query_string.decode()
+            url += "?" + query_string.decode()
 
         return http.URL(url)
 
 
 class SchemeComponent(Component):
-    def resolve(self,
-                scope: ASGIScope) -> http.Scheme:
-        return http.Scheme(scope['scheme'])
+
+    def resolve(self, scope: ASGIScope) -> http.Scheme:
+        return http.Scheme(scope["scheme"])
 
 
 class HostComponent(Component):
-    def resolve(self,
-                scope: ASGIScope) -> http.Host:
-        return http.Host(scope['server'][0])
+
+    def resolve(self, scope: ASGIScope) -> http.Host:
+        return http.Host(scope["server"][0])
 
 
 class PortComponent(Component):
-    def resolve(self,
-                scope: ASGIScope) -> http.Port:
-        return http.Port(scope['server'][1])
+
+    def resolve(self, scope: ASGIScope) -> http.Port:
+        return http.Port(scope["server"][1])
 
 
 class PathComponent(Component):
-    def resolve(self,
-                scope: ASGIScope) -> http.Path:
-        return http.Path(scope.get('root_path', '') + scope['path'])
+
+    def resolve(self, scope: ASGIScope) -> http.Path:
+        return http.Path(scope.get("root_path", "") + scope["path"])
 
 
 class QueryStringComponent(Component):
-    def resolve(self,
-                scope: ASGIScope) -> http.QueryString:
-        return http.QueryString(scope['query_string'].decode())
+
+    def resolve(self, scope: ASGIScope) -> http.QueryString:
+        return http.QueryString(scope["query_string"].decode())
 
 
 class QueryParamsComponent(Component):
-    def resolve(self,
-                scope: ASGIScope) -> http.QueryParams:
-        query_string = scope['query_string'].decode()
+
+    def resolve(self, scope: ASGIScope) -> http.QueryParams:
+        query_string = scope["query_string"].decode()
         return http.QueryParams(parse_qsl(query_string))
 
 
 class QueryParamComponent(Component):
-    def resolve(self,
-                parameter: Parameter,
-                query_params: http.QueryParams) -> http.QueryParam:
+
+    def resolve(
+        self, parameter: Parameter, query_params: http.QueryParams
+    ) -> http.QueryParam:
         name = parameter.name
         if name not in query_params:
             return None
+
         return http.QueryParam(query_params[name])
 
 
 class HeadersComponent(Component):
-    def resolve(self,
-                scope: ASGIScope) -> http.Headers:
-        return http.Headers([
-            (key.decode(), value.decode())
-            for key, value in scope['headers']
-        ])
+
+    def resolve(self, scope: ASGIScope) -> http.Headers:
+        return http.Headers(
+            [(key.decode(), value.decode()) for key, value in scope["headers"]]
+        )
 
 
 class HeaderComponent(Component):
-    def resolve(self,
-                parameter: Parameter,
-                headers: http.Headers) -> http.Header:
-        name = parameter.name.replace('_', '-')
+
+    def resolve(self, parameter: Parameter, headers: http.Headers) -> http.Header:
+        name = parameter.name.replace("_", "-")
         if name not in headers:
             return None
+
         return http.Header(headers[name])
 
 
 class BodyComponent(Component):
-    async def resolve(self,
-                      receive: ASGIReceive) -> http.Body:
-        body = b''
+
+    async def resolve(self, receive: ASGIReceive) -> http.Body:
+        body = b""
         while True:
             message = await receive()
-            if not message['type'] == 'http.request':
+            if not message["type"] == "http.request":
                 error = "'Unexpected ASGI message type '%s'."
-                raise Exception(error % message['type'])
-            body += message.get('body', b'')
-            if not message.get('more_body', False):
+                raise Exception(error % message["type"])
+
+            body += message.get("body", b"")
+            if not message.get("more_body", False):
                 break
 
         return http.Body(body)
 
 
 class RequestComponent(Component):
-    def resolve(self,
-                method: http.Method,
-                url: http.URL,
-                headers: http.Headers,
-                body: http.Body) -> http.Request:
+
+    def resolve(
+        self, method: http.Method, url: http.URL, headers: http.Headers, body: http.Body
+    ) -> http.Request:
         return http.Request(method, url, headers, body)
 
 
@@ -139,5 +140,5 @@ ASGI_COMPONENTS = (
     HeadersComponent(),
     HeaderComponent(),
     BodyComponent(),
-    RequestComponent()
+    RequestComponent(),
 )

--- a/apistar/server/components.py
+++ b/apistar/server/components.py
@@ -4,6 +4,7 @@ from apistar import exceptions
 
 
 class Component():
+
     def identity(self, parameter: inspect.Parameter):
         """
         Each component needs a unique identifier string that we use for lookups
@@ -16,7 +17,7 @@ class Component():
         # that is additionally parameterized by the parameter name.
         args = inspect.signature(self.resolve).parameters.values()
         if inspect.Parameter in [arg.annotation for arg in args]:
-            return annotation_name + ':' + parameter_name
+            return annotation_name + ":" + parameter_name
 
         # Standard case is to use the class name, lowercased.
         return annotation_name
@@ -36,9 +37,10 @@ class Component():
         if return_annotation is inspect.Signature.empty:
             msg = (
                 'Component "%s" must include a return annotation on the '
-                '`resolve()` method, or override `can_handle_parameter`'
+                "`resolve()` method, or override `can_handle_parameter`"
             )
             raise exceptions.ConfigurationError(msg % self.__class__.__name__)
+
         return parameter.annotation is return_annotation
 
     def resolve(self):

--- a/apistar/server/handlers.py
+++ b/apistar/server/handlers.py
@@ -7,19 +7,23 @@ from apistar.server.wsgi import WSGIEnviron, WSGIStartResponse
 def serve_schema(app: App):
     codec = OpenAPICodec()
     content = codec.encode(app.document)
-    headers = {'Content-Type': 'application/vnd.oai.openapi'}
+    headers = {"Content-Type": "application/vnd.oai.openapi"}
     return http.Response(content, headers=headers)
 
 
 def serve_documentation(app: App):
-    template_name = 'apistar/docs/index.html'
+    template_name = "apistar/docs/index.html"
     return app.render_template(template_name, document=app.document)
 
 
-def serve_static_wsgi(app: App, environ: WSGIEnviron, start_response: WSGIStartResponse):
+def serve_static_wsgi(
+    app: App, environ: WSGIEnviron, start_response: WSGIStartResponse
+):
     return app.statics(environ, start_response)
 
 
-async def serve_static_asgi(app: App, scope: ASGIScope, receive: ASGIReceive, send: ASGISend):
+async def serve_static_asgi(
+    app: App, scope: ASGIScope, receive: ASGIReceive, send: ASGISend
+):
     instance = app.statics(scope)
     await instance(receive, send)

--- a/apistar/server/injector.py
+++ b/apistar/server/injector.py
@@ -5,6 +5,7 @@ from apistar.exceptions import ConfigurationError
 
 
 class BaseInjector():
+
     def run(self, func, state):
         raise NotImplementedError()
 
@@ -15,14 +16,14 @@ class Injector(BaseInjector):
     def __init__(self, components, initial):
         self.components = components
         self.initial = initial
-        self.reverse_initial = {
-            val: key for key, val in initial.items()
-        }
+        self.reverse_initial = {val: key for key, val in initial.items()}
         self.resolver_cache = {}
 
-    def resolve_function(self, func, output_name=None, seen_state=None, parent_parameter=None):
+    def resolve_function(
+        self, func, output_name=None, seen_state=None, parent_parameter=None
+    ):
         if output_name is None:
-            output_name = 'response'
+            output_name = "response"
         if seen_state is None:
             seen_state = set(self.initial)
 
@@ -33,8 +34,8 @@ class Injector(BaseInjector):
         parameters = inspect.signature(func).parameters.values()
         for parameter in parameters:
             # The 'response' keyword always indicates the previous return value.
-            if parameter.name == 'response':
-                kwargs['response'] = 'response'
+            if parameter.name == "response":
+                kwargs["response"] = "response"
                 continue
 
             # Check if the parameter class exists in 'initial'.
@@ -61,9 +62,10 @@ class Injector(BaseInjector):
                             func=component.resolve,
                             output_name=identity,
                             seen_state=seen_state,
-                            parent_parameter=parameter
+                            parent_parameter=parameter,
                         )
                     break
+
             else:
                 msg = 'No component able to handle parameter "%s" on function "%s".'
                 raise ConfigurationError(msg % (parameter.name, func.__name__))
@@ -71,7 +73,7 @@ class Injector(BaseInjector):
         is_async = asyncio.iscoroutinefunction(func)
         if is_async and not self.allow_async:
             msg = 'Function "%s" may not be async.'
-            raise ConfigurationError(msg % (func.__name__, ))
+            raise ConfigurationError(msg % (func.__name__,))
 
         step = (func, is_async, kwargs, consts, output_name)
         steps.append(step)
@@ -98,7 +100,7 @@ class Injector(BaseInjector):
             func_kwargs.update(consts)
             state[output_name] = func(**func_kwargs)
 
-        return state['response']
+        return state["response"]
 
 
 class ASyncInjector(Injector):
@@ -120,4 +122,4 @@ class ASyncInjector(Injector):
             else:
                 state[output_name] = func(**func_kwargs)
 
-        return state['response']
+        return state["response"]

--- a/apistar/server/router.py
+++ b/apistar/server/router.py
@@ -11,6 +11,7 @@ from apistar.server.core import Include, Route
 
 
 class BaseRouter():
+
     def lookup(self, path: str, method: str):
         raise NotImplementedError()
 
@@ -19,49 +20,38 @@ class BaseRouter():
 
 
 class Router(BaseRouter):
+
     def __init__(self, routes):
         rules = []
         name_lookups = {}
 
         for path, name, route in self.walk_routes(routes):
-            path_params = [
-                item.strip('{}') for item in re.findall('{[^}]*}', path)
-            ]
+            path_params = [item.strip("{}") for item in re.findall("{[^}]*}", path)]
             args = inspect.signature(route.handler).parameters
             for path_param in path_params:
-                if path_param.startswith('+'):
+                if path_param.startswith("+"):
                     path = path.replace(
-                        '{%s}' % path_param,
-                        "<path:%s>" % path_param.lstrip('+')
+                        "{%s}" % path_param, "<path:%s>" % path_param.lstrip("+")
                     )
                 elif path_param in args and args[path_param].annotation is int:
-                    path = path.replace(
-                        '{%s}' % path_param,
-                        "<int:%s>" % path_param
-                    )
+                    path = path.replace("{%s}" % path_param, "<int:%s>" % path_param)
                 elif path_param in args and args[path_param].annotation is float:
-                    path = path.replace(
-                        '{%s}' % path_param,
-                        "<float:%s>" % path_param
-                    )
+                    path = path.replace("{%s}" % path_param, "<float:%s>" % path_param)
                 else:
-                    path = path.replace(
-                        '{%s}' % path_param,
-                        "<string:%s>" % path_param
-                    )
+                    path = path.replace("{%s}" % path_param, "<string:%s>" % path_param)
 
             rule = Rule(path, methods=[route.method], endpoint=name)
             rules.append(rule)
             name_lookups[name] = route
 
-        self.adapter = Map(rules).bind('')
+        self.adapter = Map(rules).bind("")
         self.name_lookups = name_lookups
 
         # Use an MRU cache for router lookups.
         self._lookup_cache = dict_type()
         self._lookup_cache_size = 10000
 
-    def walk_routes(self, routes, url_prefix='', name_prefix=''):
+    def walk_routes(self, routes, url_prefix="", name_prefix=""):
         walked = []
         for item in routes:
             if isinstance(item, Route):
@@ -69,17 +59,16 @@ class Router(BaseRouter):
                 walked.append(result)
             elif isinstance(item, Include):
                 result = self.walk_routes(
-                    item.routes,
-                    url_prefix + item.url,
-                    name_prefix + item.name + ':'
+                    item.routes, url_prefix + item.url, name_prefix + item.name + ":"
                 )
                 walked.extend(result)
         return walked
 
     def lookup(self, path: str, method: str):
-        lookup_key = method + ' ' + path
+        lookup_key = method + " " + path
         try:
             return self._lookup_cache[lookup_key]
+
         except KeyError:
             pass
 
@@ -87,8 +76,10 @@ class Router(BaseRouter):
             name, path_params = self.adapter.match(path, method)
         except werkzeug.exceptions.NotFound:
             raise exceptions.NotFound() from None
+
         except werkzeug.exceptions.MethodNotAllowed:
             raise exceptions.MethodNotAllowed() from None
+
         except werkzeug.routing.RequestRedirect as exc:
             path = urlparse(exc.new_url).path
             raise exceptions.Found(path) from None
@@ -104,5 +95,6 @@ class Router(BaseRouter):
     def reverse_url(self, name: str, **params) -> str:
         try:
             return self.adapter.build(name, params)
+
         except werkzeug.routing.BuildError as exc:
             raise exceptions.NoReverseMatch(str(exc)) from None

--- a/apistar/server/staticfiles.py
+++ b/apistar/server/staticfiles.py
@@ -5,6 +5,7 @@ from apistar.compat import aiofiles, whitenoise
 
 
 class BaseStaticFiles():
+
     def __call__(self, environ, start_response):
         raise NotImplementedError()
 
@@ -21,7 +22,7 @@ class StaticFiles(BaseStaticFiles):
 
     def check_requirements(self):
         if whitenoise is None:
-            raise RuntimeError('`whitenoise` must be installed to use `StaticFiles`.')
+            raise RuntimeError("`whitenoise` must be installed to use `StaticFiles`.")
 
     def __call__(self, environ, start_response):
         return self.whitenoise(environ, start_response)
@@ -34,51 +35,61 @@ class ASyncStaticFiles(StaticFiles):
     """
     Static file handling for ASGI applications, using `whitenoise` and `aiofiles`.
     """
+
     def check_requirements(self):
         if whitenoise is None:
-            raise RuntimeError('`whitenoise` must be installed to use `ASyncStaticFiles`.')
+            raise RuntimeError(
+                "`whitenoise` must be installed to use `ASyncStaticFiles`."
+            )
+
         if aiofiles is None:
-            raise RuntimeError('`aiofiles` must be installed to use `ASyncStaticFiles`.')
+            raise RuntimeError(
+                "`aiofiles` must be installed to use `ASyncStaticFiles`."
+            )
 
     def __call__(self, scope):
-        path = scope['path'].encode('iso-8859-1', 'replace').decode('utf-8', 'replace')
+        path = scope["path"].encode("iso-8859-1", "replace").decode("utf-8", "replace")
         if self.whitenoise.autorefresh:
             static_file = self.whitenoise.find_file(path)
         else:
             static_file = self.whitenoise.files.get(path)
         if static_file is None:
+
             async def not_found(receive, send):
                 raise exceptions.NotFound()
+
             return not_found
+
         else:
             return ASGIFileSession(static_file, scope)
 
 
 class ASGIFileSession():
+
     def __init__(self, static_file, scope):
         self.static_file = static_file
         self.scope = scope
         self.headers = {}
-        for key, value in scope['headers']:
-            wsgi_key = 'HTTP_' + key.decode().upper().replace('-', '_')
+        for key, value in scope["headers"]:
+            wsgi_key = "HTTP_" + key.decode().upper().replace("-", "_")
             wsgi_value = value.decode()
             self.headers[wsgi_key] = wsgi_value
 
     async def __call__(self, receive, send):
-        status, headers, file = await self.get_response(self.scope['method'], self.headers)
-        await send({
-            'type': 'http.response.start',
-            'status': status.value,
-            'headers': [
-                (key.lower().encode(), value.encode())
-                for key, value in headers
-            ]
-        })
+        status, headers, file = await self.get_response(
+            self.scope["method"], self.headers
+        )
+        await send(
+            {
+                "type": "http.response.start",
+                "status": status.value,
+                "headers": [
+                    (key.lower().encode(), value.encode()) for key, value in headers
+                ],
+            }
+        )
         if file is None:
-            await send({
-                'type': 'http.response.body',
-                'body': b''
-            })
+            await send({"type": "http.response.body", "body": b""})
         else:
             chunk = await file.read(8192)
             more_body = True
@@ -87,25 +98,25 @@ class ASGIFileSession():
                 next_chunk = await file.read(8192)
                 more_body = bool(next_chunk)
 
-                await send({
-                    'type': 'http.response.body',
-                    'body': chunk,
-                    'more_body': more_body
-                })
+                await send(
+                    {
+                        "type": "http.response.body",
+                        "body": chunk,
+                        "more_body": more_body,
+                    }
+                )
                 chunk = next_chunk
 
     async def get_response(self, method, request_headers):
-        if method != 'GET' and method != 'HEAD':
-            return (
-                HTTPStatus.METHOD_NOT_ALLOWED,
-                (('Allow', 'GET, HEAD'),),
-                None
-            )
+        if method != "GET" and method != "HEAD":
+            return (HTTPStatus.METHOD_NOT_ALLOWED, (("Allow", "GET, HEAD"),), None)
+
         elif self.static_file.file_not_modified(request_headers):
             return self.static_file.not_modified_response
+
         path, headers = self.static_file.get_path_and_headers(request_headers)
-        if method != 'HEAD':
-            file_handle = await aiofiles.open(path, 'rb')
+        if method != "HEAD":
+            file_handle = await aiofiles.open(path, "rb")
         else:
             file_handle = None
         return (HTTPStatus.OK, headers, file_handle)

--- a/apistar/server/templates.py
+++ b/apistar/server/templates.py
@@ -2,16 +2,16 @@ from apistar.compat import jinja2
 
 
 class BaseTemplates():
+
     def render_template(self, path: str, **context):
         raise NotImplementedError()
 
 
 class Templates(BaseTemplates):
-    def __init__(self,
-                 template_dir: str=None,
-                 global_context: dict=None):
+
+    def __init__(self, template_dir: str = None, global_context: dict = None):
         if jinja2 is None:
-            raise RuntimeError('`jinja2` must be installed to use `Templates`.')
+            raise RuntimeError("`jinja2` must be installed to use `Templates`.")
 
         global_context = global_context if global_context else {}
         loader = jinja2.FileSystemLoader(template_dir)

--- a/apistar/server/validation.py
+++ b/apistar/server/validation.py
@@ -6,25 +6,24 @@ from apistar.conneg import negotiate_content_type
 from apistar.server.components import Component
 from apistar.server.core import Route
 
-ValidatedPathParams = typing.NewType('ValidatedPathParams', dict)
-ValidatedQueryParams = typing.NewType('ValidatedQueryParams', dict)
-ValidatedRequestData = typing.TypeVar('ValidatedRequestData')
+ValidatedPathParams = typing.NewType("ValidatedPathParams", dict)
+ValidatedQueryParams = typing.NewType("ValidatedQueryParams", dict)
+ValidatedRequestData = typing.TypeVar("ValidatedRequestData")
 
 
 class RequestDataComponent(Component):
+
     def __init__(self):
         self.codecs = [codecs.JSONCodec()]
 
     def can_handle_parameter(self, parameter: inspect.Parameter):
         return parameter.annotation is http.RequestData
 
-    def resolve(self,
-                content: http.Body,
-                headers: http.Headers):
+    def resolve(self, content: http.Body, headers: http.Headers):
         if not content:
             return None
 
-        content_type = headers.get('Content-Type')
+        content_type = headers.get("Content-Type")
 
         try:
             codec = negotiate_content_type(self.codecs, content_type)
@@ -33,14 +32,16 @@ class RequestDataComponent(Component):
 
         try:
             return codec.decode(content, headers=headers)
+
         except exceptions.ParseError as exc:
             raise exceptions.BadRequest(str(exc))
 
 
 class ValidatePathParamsComponent(Component):
-    def resolve(self,
-                route: Route,
-                path_params: http.PathParams) -> ValidatedPathParams:
+
+    def resolve(
+        self, route: Route, path_params: http.PathParams
+    ) -> ValidatedPathParams:
         path_fields = route.link.get_path_fields()
 
         validator = validators.Object(
@@ -48,20 +49,22 @@ class ValidatePathParamsComponent(Component):
                 (field.name, field.schema if field.schema else validators.Any())
                 for field in path_fields
             ],
-            required=[field.name for field in path_fields]
+            required=[field.name for field in path_fields],
         )
 
         try:
             path_params = validator.validate(path_params, allow_coerce=True)
         except validators.ValidationError as exc:
             raise exceptions.NotFound(exc.detail)
+
         return ValidatedPathParams(path_params)
 
 
 class ValidateQueryParamsComponent(Component):
-    def resolve(self,
-                route: Route,
-                query_params: http.QueryParams) -> ValidatedQueryParams:
+
+    def resolve(
+        self, route: Route, query_params: http.QueryParams
+    ) -> ValidatedQueryParams:
         query_fields = route.link.get_query_fields()
 
         validator = validators.Object(
@@ -69,23 +72,23 @@ class ValidateQueryParamsComponent(Component):
                 (field.name, field.schema if field.schema else validators.Any())
                 for field in query_fields
             ],
-            required=[field.name for field in query_fields if field.required]
+            required=[field.name for field in query_fields if field.required],
         )
 
         try:
             query_params = validator.validate(query_params, allow_coerce=True)
         except validators.ValidationError as exc:
             raise exceptions.BadRequest(exc.detail)
+
         return ValidatedQueryParams(query_params)
 
 
 class ValidateRequestDataComponent(Component):
+
     def can_handle_parameter(self, parameter: inspect.Parameter):
         return parameter.annotation is ValidatedRequestData
 
-    def resolve(self,
-                route: Route,
-                data: http.RequestData):
+    def resolve(self, route: Route, data: http.RequestData):
         body_field = route.link.get_body_field()
 
         if not body_field or not body_field.schema:
@@ -95,18 +98,22 @@ class ValidateRequestDataComponent(Component):
 
         try:
             return validator.validate(data, allow_coerce=True)
+
         except validators.ValidationError as exc:
             raise exceptions.BadRequest(exc.detail)
 
 
 class PrimitiveParamComponent(Component):
+
     def can_handle_parameter(self, parameter: inspect.Parameter):
         return parameter.annotation in (str, int, float, bool, parameter.empty)
 
-    def resolve(self,
-                parameter: inspect.Parameter,
-                path_params: ValidatedPathParams,
-                query_params: ValidatedQueryParams):
+    def resolve(
+        self,
+        parameter: inspect.Parameter,
+        path_params: ValidatedPathParams,
+        query_params: ValidatedQueryParams,
+    ):
         params = path_params if (parameter.name in path_params) else query_params
         has_default = parameter.default is not parameter.empty
         allow_null = parameter.default is None
@@ -116,30 +123,33 @@ class PrimitiveParamComponent(Component):
             str: validators.String(allow_null=allow_null),
             int: validators.Integer(allow_null=allow_null),
             float: validators.Number(allow_null=allow_null),
-            bool: validators.Boolean(allow_null=allow_null)
-        }[parameter.annotation]
+            bool: validators.Boolean(allow_null=allow_null),
+        }[
+            parameter.annotation
+        ]
 
         validator = validators.Object(
             properties=[(parameter.name, param_validator)],
-            required=[] if has_default else [parameter.name]
+            required=[] if has_default else [parameter.name],
         )
 
         try:
             params = validator.validate(params, allow_coerce=True)
         except validators.ValidationError as exc:
             raise exceptions.NotFound(exc.detail)
+
         return params.get(parameter.name, parameter.default)
 
 
 class CompositeParamComponent(Component):
+
     def can_handle_parameter(self, parameter: inspect.Parameter):
         return issubclass(parameter.annotation, types.Type)
 
-    def resolve(self,
-                parameter: inspect.Parameter,
-                data: ValidatedRequestData):
+    def resolve(self, parameter: inspect.Parameter, data: ValidatedRequestData):
         try:
             return parameter.annotation(data)
+
         except validators.ValidationError as exc:
             raise exceptions.BadRequest(exc.detail)
 
@@ -150,5 +160,5 @@ VALIDATION_COMPONENTS = (
     ValidateQueryParamsComponent(),
     ValidateRequestDataComponent(),
     PrimitiveParamComponent(),
-    CompositeParamComponent()
+    CompositeParamComponent(),
 )

--- a/apistar/server/wsgi.py
+++ b/apistar/server/wsgi.py
@@ -9,116 +9,115 @@ from werkzeug.wsgi import get_input_stream
 from apistar import http
 from apistar.server.components import Component
 
-WSGIEnviron = typing.NewType('WSGIEnviron', dict)
-WSGIStartResponse = typing.NewType('WSGIStartResponse', typing.Callable)
+WSGIEnviron = typing.NewType("WSGIEnviron", dict)
+WSGIStartResponse = typing.NewType("WSGIStartResponse", typing.Callable)
 
 
-RESPONSE_STATUS_TEXT = {
-    code: str(code) for code in range(100, 600)
-}
-RESPONSE_STATUS_TEXT.update({
-    status.value: "%d %s" % (status.value, status.phrase)
-    for status in HTTPStatus
-})
+RESPONSE_STATUS_TEXT = {code: str(code) for code in range(100, 600)}
+RESPONSE_STATUS_TEXT.update(
+    {status.value: "%d %s" % (status.value, status.phrase) for status in HTTPStatus}
+)
 
 
 class MethodComponent(Component):
-    def resolve(self,
-                environ: WSGIEnviron) -> http.Method:
-        return http.Method(environ['REQUEST_METHOD'].upper())
+
+    def resolve(self, environ: WSGIEnviron) -> http.Method:
+        return http.Method(environ["REQUEST_METHOD"].upper())
 
 
 class URLComponent(Component):
-    def resolve(self,
-                environ: WSGIEnviron) -> http.URL:
+
+    def resolve(self, environ: WSGIEnviron) -> http.URL:
         return http.URL(request_uri(environ))
 
 
 class SchemeComponent(Component):
-    def resolve(self,
-                environ: WSGIEnviron) -> http.Scheme:
-        return http.Scheme(environ['wsgi.url_scheme'])
+
+    def resolve(self, environ: WSGIEnviron) -> http.Scheme:
+        return http.Scheme(environ["wsgi.url_scheme"])
 
 
 class HostComponent(Component):
-    def resolve(self,
-                environ: WSGIEnviron) -> http.Host:
-        return http.Host(environ.get('HTTP_HOST') or environ['SERVER_NAME'])
+
+    def resolve(self, environ: WSGIEnviron) -> http.Host:
+        return http.Host(environ.get("HTTP_HOST") or environ["SERVER_NAME"])
 
 
 class PortComponent(Component):
-    def resolve(self,
-                environ: WSGIEnviron) -> http.Port:
-        if environ['wsgi.url_scheme'] == 'https':
-            return http.Port(int(environ.get('SERVER_PORT', 443)))
-        return http.Port(int(environ.get('SERVER_PORT', 80)))
+
+    def resolve(self, environ: WSGIEnviron) -> http.Port:
+        if environ["wsgi.url_scheme"] == "https":
+            return http.Port(int(environ.get("SERVER_PORT", 443)))
+
+        return http.Port(int(environ.get("SERVER_PORT", 80)))
 
 
 class PathComponent(Component):
-    def resolve(self,
-                environ: WSGIEnviron) -> http.Path:
-        return http.Path(environ['SCRIPT_NAME'] + environ['PATH_INFO'])
+
+    def resolve(self, environ: WSGIEnviron) -> http.Path:
+        return http.Path(environ["SCRIPT_NAME"] + environ["PATH_INFO"])
 
 
 class QueryStringComponent(Component):
-    def resolve(self,
-                environ: WSGIEnviron) -> http.QueryString:
-        return http.QueryString(environ.get('QUERY_STRING', ''))
+
+    def resolve(self, environ: WSGIEnviron) -> http.QueryString:
+        return http.QueryString(environ.get("QUERY_STRING", ""))
 
 
 class QueryParamsComponent(Component):
-    def resolve(self,
-                environ: WSGIEnviron) -> http.QueryParams:
-        query_string = environ.get('QUERY_STRING', '')
+
+    def resolve(self, environ: WSGIEnviron) -> http.QueryParams:
+        query_string = environ.get("QUERY_STRING", "")
         return http.QueryParams(parse_qsl(query_string))
 
 
 class QueryParamComponent(Component):
-    def resolve(self,
-                parameter: Parameter,
-                query_params: http.QueryParams) -> http.QueryParam:
+
+    def resolve(
+        self, parameter: Parameter, query_params: http.QueryParams
+    ) -> http.QueryParam:
         name = parameter.name
         if name not in query_params:
             return None
+
         return http.QueryParam(query_params[name])
 
 
 class HeadersComponent(Component):
-    def resolve(self,
-                environ: WSGIEnviron) -> http.Headers:
+
+    def resolve(self, environ: WSGIEnviron) -> http.Headers:
         header_items = []
         for key, value in environ.items():
-            if key.startswith('HTTP_'):
-                header = (key[5:].lower().replace('_', '-'), value)
+            if key.startswith("HTTP_"):
+                header = (key[5:].lower().replace("_", "-"), value)
                 header_items.append(header)
-            elif key in ('CONTENT_TYPE', 'CONTENT_LENGTH'):
-                header = (key.lower().replace('_', '-'), value)
+            elif key in ("CONTENT_TYPE", "CONTENT_LENGTH"):
+                header = (key.lower().replace("_", "-"), value)
                 header_items.append(header)
         return http.Headers(header_items)
 
 
 class HeaderComponent(Component):
-    def resolve(self,
-                parameter: Parameter,
-                headers: http.Headers) -> http.Header:
-        name = parameter.name.replace('_', '-')
+
+    def resolve(self, parameter: Parameter, headers: http.Headers) -> http.Header:
+        name = parameter.name.replace("_", "-")
         if name not in headers:
             return None
+
         return http.Header(headers[name])
 
 
 class BodyComponent(Component):
-    def resolve(self,
-                environ: WSGIEnviron) -> http.Body:
+
+    def resolve(self, environ: WSGIEnviron) -> http.Body:
         return http.Body(get_input_stream(environ).read())
 
 
 class RequestComponent(Component):
-    def resolve(self,
-                method: http.Method,
-                url: http.URL,
-                headers: http.Headers,
-                body: http.Body) -> http.Request:
+
+    def resolve(
+        self, method: http.Method, url: http.URL, headers: http.Headers, body: http.Body
+    ) -> http.Request:
         return http.Request(method, url, headers, body)
 
 
@@ -135,5 +134,5 @@ WSGI_COMPONENTS = (
     HeadersComponent(),
     HeaderComponent(),
     BodyComponent(),
-    RequestComponent()
+    RequestComponent(),
 )

--- a/apistar/test.py
+++ b/apistar/test.py
@@ -7,6 +7,7 @@ import requests
 
 
 class _HeaderDict(requests.packages.urllib3._collections.HTTPHeaderDict):
+
     def get_all(self, key, default):
         return self.getheaders(key)
 
@@ -16,6 +17,7 @@ class _MockOriginalResponse(object):
     We have to jump through some hoops to present the response as if
     it was made using urllib3.
     """
+
     def __init__(self, headers):
         self.msg = _HeaderDict(headers)
         self.closed = False
@@ -32,10 +34,13 @@ class _WSGIAdapter(requests.adapters.HTTPAdapter):
     A transport adapter for `requests` that makes requests directly to a
     WSGI app, rather than making actual HTTP requests over the network.
     """
+
     def __init__(self, app: typing.Callable) -> None:
         self.app = app
 
-    def get_environ(self, request: requests.PreparedRequest) -> typing.Dict[str, typing.Any]:
+    def get_environ(
+        self, request: requests.PreparedRequest
+    ) -> typing.Dict[str, typing.Any]:
         """
         Given a `requests.PreparedRequest` instance, return a WSGI environ dict.
         """
@@ -47,26 +52,26 @@ class _WSGIAdapter(requests.adapters.HTTPAdapter):
 
         url_components = urlparse(request.url)
         environ = {
-            'REQUEST_METHOD': request.method,
-            'wsgi.url_scheme': url_components.scheme,
-            'SCRIPT_NAME': '',
-            'PATH_INFO': unquote(url_components.path),
-            'wsgi.input': io.BytesIO(body_bytes),
+            "REQUEST_METHOD": request.method,
+            "wsgi.url_scheme": url_components.scheme,
+            "SCRIPT_NAME": "",
+            "PATH_INFO": unquote(url_components.path),
+            "wsgi.input": io.BytesIO(body_bytes),
         }  # type: typing.Dict[str, typing.Any]
 
         if url_components.query:
-            environ['QUERY_STRING'] = url_components.query
+            environ["QUERY_STRING"] = url_components.query
 
         if url_components.port:
-            environ['SERVER_NAME'] = url_components.hostname
-            environ['SERVER_PORT'] = str(url_components.port)
+            environ["SERVER_NAME"] = url_components.hostname
+            environ["SERVER_PORT"] = str(url_components.port)
         else:
-            environ['HTTP_HOST'] = url_components.hostname
+            environ["HTTP_HOST"] = url_components.hostname
 
         for key, value in request.headers.items():
-            key = key.upper().replace('-', '_')
-            if key not in ('CONTENT_LENGTH', 'CONTENT_TYPE'):
-                key = 'HTTP_' + key
+            key = key.upper().replace("-", "_")
+            if key not in ("CONTENT_LENGTH", "CONTENT_TYPE"):
+                key = "HTTP_" + key
             environ[key] = value
 
         return environ
@@ -78,20 +83,20 @@ class _WSGIAdapter(requests.adapters.HTTPAdapter):
         raw_kwargs = {}
 
         def start_response(wsgi_status, wsgi_headers):
-            status, _, reason = wsgi_status.partition(' ')
-            raw_kwargs['status'] = int(status)
-            raw_kwargs['reason'] = reason
-            raw_kwargs['headers'] = wsgi_headers
-            raw_kwargs['version'] = 11
-            raw_kwargs['preload_content'] = False
-            raw_kwargs['original_response'] = _MockOriginalResponse(wsgi_headers)
+            status, _, reason = wsgi_status.partition(" ")
+            raw_kwargs["status"] = int(status)
+            raw_kwargs["reason"] = reason
+            raw_kwargs["headers"] = wsgi_headers
+            raw_kwargs["version"] = 11
+            raw_kwargs["preload_content"] = False
+            raw_kwargs["original_response"] = _MockOriginalResponse(wsgi_headers)
 
         # Make the outgoing request via WSGI.
         environ = self.get_environ(request)
         wsgi_response = self.app(environ, start_response)
 
         # Build the underlying urllib3.HTTPResponse
-        raw_kwargs['body'] = io.BytesIO(b''.join(wsgi_response))
+        raw_kwargs["body"] = io.BytesIO(b"".join(wsgi_response))
         raw = requests.packages.urllib3.HTTPResponse(**raw_kwargs)
 
         # Build the requests.Response
@@ -99,43 +104,43 @@ class _WSGIAdapter(requests.adapters.HTTPAdapter):
 
 
 class _ASGIAdapter(requests.adapters.HTTPAdapter):
+
     def __init__(self, app: typing.Callable) -> None:
         self.app = app
 
     def send(self, request, *args, **kwargs):
         scheme, netloc, path, params, query, fragement = urlparse(request.url)
-        if ':' in netloc:
-            host, port = netloc.split(':', 1)
+        if ":" in netloc:
+            host, port = netloc.split(":", 1)
             port = int(port)
         else:
             host = netloc
-            port = {'http': 80, 'https': 443}[scheme]
+            port = {"http": 80, "https": 443}[scheme]
 
         # Include the 'host' header.
-        if 'host' in request.headers:
+        if "host" in request.headers:
             headers = []
         elif port == 80:
-            headers = [[b'host', host.encode()]]
+            headers = [[b"host", host.encode()]]
         else:
-            headers = [[b'host', ('%s:%d' % (host, port)).encode()]]
+            headers = [[b"host", ("%s:%d" % (host, port)).encode()]]
 
         # Include other request headers.
         headers += [
-            [key.encode(), value.encode()]
-            for key, value in request.headers.items()
+            [key.encode(), value.encode()] for key, value in request.headers.items()
         ]
 
         scope = {
-            'type': 'http',
-            'http_version': '1.1',
-            'method': request.method,
-            'path': unquote(path),
-            'root_path': '',
-            'scheme': scheme,
-            'query_string': query.encode(),
-            'headers': headers,
-            'client': ['testclient', 50000],
-            'server': [host, port],
+            "type": "http",
+            "http_version": "1.1",
+            "method": request.method,
+            "path": unquote(path),
+            "root_path": "",
+            "scheme": scheme,
+            "query_string": query.encode(),
+            "headers": headers,
+            "client": ["testclient", 50000],
+            "server": [host, port],
         }
 
         async def receive():
@@ -143,30 +148,28 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
             if isinstance(body, str):
                 body_bytes = body.encode("utf-8")  # type: bytes
             elif body is None:
-                body_bytes = b''
+                body_bytes = b""
             else:
                 body_bytes = body
-            return {
-                'type': 'http.request',
-                'body': body_bytes,
-            }
+            return {"type": "http.request", "body": body_bytes}
 
         async def send(message):
-            if message['type'] == 'http.response.start':
-                raw_kwargs['version'] = 11
-                raw_kwargs['status'] = message['status']
-                raw_kwargs['headers'] = [
-                    (key.decode(), value.decode())
-                    for key, value in message['headers']
+            if message["type"] == "http.response.start":
+                raw_kwargs["version"] = 11
+                raw_kwargs["status"] = message["status"]
+                raw_kwargs["headers"] = [
+                    (key.decode(), value.decode()) for key, value in message["headers"]
                 ]
-                raw_kwargs['preload_content'] = False
-                raw_kwargs['original_response'] = _MockOriginalResponse(raw_kwargs['headers'])
-            elif message['type'] == 'http.response.body':
-                raw_kwargs['body'] = io.BytesIO(message['body'])
-            elif message['type'] == 'http.disconnect':
+                raw_kwargs["preload_content"] = False
+                raw_kwargs["original_response"] = _MockOriginalResponse(
+                    raw_kwargs["headers"]
+                )
+            elif message["type"] == "http.response.body":
+                raw_kwargs["body"] = io.BytesIO(message["body"])
+            elif message["type"] == "http.disconnect":
                 pass
             else:
-                raise Exception("Unknown ASGI message type: %s" % message['type'])
+                raise Exception("Unknown ASGI message type: %s" % message["type"])
 
         raw_kwargs = {}
         connection = self.app(scope)
@@ -179,30 +182,35 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
 
 
 class _TestClient(requests.Session):
+
     def __init__(self, app: typing.Callable, scheme: str, hostname: str) -> None:
         super(_TestClient, self).__init__()
-        if app.interface == 'asgi':
+        if app.interface == "asgi":
             adapter = _ASGIAdapter(app)
         else:
             adapter = _WSGIAdapter(app)
-        self.mount('http://', adapter)
-        self.mount('https://', adapter)
-        self.headers.update({'User-Agent': 'testclient'})
+        self.mount("http://", adapter)
+        self.mount("https://", adapter)
+        self.headers.update({"User-Agent": "testclient"})
         self.scheme = scheme
         self.hostname = hostname
 
-    def request(self, method: str, url: str, **kwargs) -> requests.Response:  # type: ignore
-        if not (url.startswith('http:') or url.startswith('https:')):
-            assert url.startswith('/'), (
+    def request(
+        self, method: str, url: str, **kwargs
+    ) -> requests.Response:  # type: ignore
+        if not (url.startswith("http:") or url.startswith("https:")):
+            assert url.startswith("/"), (
                 "TestClient expected either "
                 "an absolute URL starting 'http:' / 'https:', "
                 "or a relative URL starting with '/'. URL was '%s'." % url
             )
-            url = '%s://%s%s' % (self.scheme, self.hostname, url)
+            url = "%s://%s%s" % (self.scheme, self.hostname, url)
         return super().request(method, url, **kwargs)
 
 
-def TestClient(app: typing.Callable, scheme: str='http', hostname: str='testserver') -> _TestClient:
+def TestClient(
+    app: typing.Callable, scheme: str = "http", hostname: str = "testserver"
+) -> _TestClient:
     """
     We have to work around py.test discovery attempting to pick up
     the `TestClient` class, by declaring this as a function.

--- a/apistar/types.py
+++ b/apistar/types.py
@@ -6,13 +6,14 @@ from apistar.exceptions import ConfigurationError, ValidationError
 
 
 class TypeMetaclass(ABCMeta):
+
     def __new__(cls, name, bases, attrs):
         properties = []
         for key, value in list(attrs.items()):
-            if key in ['keys', 'items', 'values', 'get', 'validator']:
+            if key in ["keys", "items", "values", "get", "validator"]:
                 msg = (
                     'Cannot use reserved name "%s" on Type "%s", as it '
-                    'clashes with the class interface.'
+                    "clashes with the class interface."
                 )
                 raise ConfigurationError(msg % (key, name))
 
@@ -20,32 +21,28 @@ class TypeMetaclass(ABCMeta):
                 attrs.pop(key)
                 properties.append((key, value))
 
-        properties = sorted(
-            properties,
-            key=lambda item: item[1]._creation_counter
-        )
-        required = [
-            key for key, value in properties
-            if not value.has_default()
-        ]
+        properties = sorted(properties, key=lambda item: item[1]._creation_counter)
+        required = [key for key, value in properties if not value.has_default()]
 
-        attrs['validator'] = validators.Object(
+        attrs["validator"] = validators.Object(
             def_name=name,
             properties=properties,
             required=required,
-            additional_properties=None
+            additional_properties=None,
         )
         return super(TypeMetaclass, cls).__new__(cls, name, bases, attrs)
 
 
 class Type(Mapping, metaclass=TypeMetaclass):
+
     def __init__(self, *args, **kwargs):
         if args:
             assert len(args) == 1
             assert not kwargs
 
             if args[0] is None or isinstance(args[0], (bool, int, float, list)):
-                raise ValidationError('Must be an object.')
+                raise ValidationError("Must be an object.")
+
             elif isinstance(args[0], dict):
                 # Instantiated with a dict.
                 value = args[0]
@@ -60,25 +57,27 @@ class Type(Mapping, metaclass=TypeMetaclass):
             value = kwargs
 
         value = self.validate(value)
-        object.__setattr__(self, '_dict', value)
+        object.__setattr__(self, "_dict", value)
 
     def validate(self, value):
         return self.validator.validate(value)
 
     def __repr__(self):
-        args = ['%s=%s' % (key, repr(value)) for key, value in self.items()]
-        arg_string = ', '.join(args)
-        return '<%s(%s)>' % (self.__class__.__name__, arg_string)
+        args = ["%s=%s" % (key, repr(value)) for key, value in self.items()]
+        arg_string = ", ".join(args)
+        return "<%s(%s)>" % (self.__class__.__name__, arg_string)
 
     def __setattr__(self, key, value):
         if key not in self._dict:
             raise AttributeError('Invalid attribute "%s"' % key)
+
         value = self.validator.properties[key].validate(value)
         self._dict[key] = value
 
     def __setitem__(self, key, value):
         if key not in self._dict:
             raise KeyError('Invalid key "%s"' % key)
+
         value = self.validator.properties[key].validate(value)
         self._dict[key] = value
 
@@ -89,10 +88,12 @@ class Type(Mapping, metaclass=TypeMetaclass):
         value = self._dict[key]
         if value is None:
             return None
+
         validator = self.validator.properties[key]
-        if hasattr(validator, 'format') and validator.format in validators.FORMATS:
+        if hasattr(validator, "format") and validator.format in validators.FORMATS:
             formatter = validators.FORMATS[validator.format]
             return formatter.to_string(value)
+
         return value
 
     def __len__(self):

--- a/apistar/utils.py
+++ b/apistar/utils.py
@@ -5,29 +5,21 @@ from apistar.types import Type
 
 
 class _CustomEncoder(json.JSONEncoder):
+
     def default(self, obj):
         if isinstance(obj, Type):
             return dict(obj)
+
         return json.JSONEncoder.default(self, obj)
 
 
 def encode_json(data, indent=False):
-    kwargs = {
-        'ensure_ascii': False,
-        'allow_nan': False,
-        'cls': _CustomEncoder
-    }
+    kwargs = {"ensure_ascii": False, "allow_nan": False, "cls": _CustomEncoder}
     if indent:
-        kwargs.update({
-            'indent': None,
-            'separators': (',', ':')
-        })
+        kwargs.update({"indent": None, "separators": (",", ":")})
     else:
-        kwargs.update({
-            'indent': 4,
-            'separators': (',', ': ')
-        })
-    return json.dumps(data, **kwargs).encode('utf-8')
+        kwargs.update({"indent": 4, "separators": (",", ": ")})
+    return json.dumps(data, **kwargs).encode("utf-8")
 
 
 def encode_jsonschema(validator, to_data_structure=False):

--- a/apistar/validators.py
+++ b/apistar/validators.py
@@ -9,9 +9,9 @@ from apistar.exceptions import ValidationError
 NO_DEFAULT = object()
 
 FORMATS = {
-    'date': formats.DateFormat(),
-    'time': formats.TimeFormat(),
-    'datetime': formats.DateTimeFormat()
+    "date": formats.DateFormat(),
+    "time": formats.TimeFormat(),
+    "datetime": formats.DateTimeFormat(),
 }
 
 
@@ -19,7 +19,14 @@ class Validator:
     errors = {}
     _creation_counter = 0
 
-    def __init__(self, title='', description='', default=NO_DEFAULT, definitions=None, def_name=None):
+    def __init__(
+        self,
+        title="",
+        description="",
+        default=NO_DEFAULT,
+        definitions=None,
+        def_name=None,
+    ):
         definitions = {} if (definitions is None) else dict_type(definitions)
 
         assert isinstance(title, str)
@@ -49,10 +56,11 @@ class Validator:
             self.validate(value)
         except ValidationError:
             return False
+
         return True
 
     def has_default(self):
-        return hasattr(self, 'default')
+        return hasattr(self, "default")
 
     def error(self, code):
         message = self.error_message(code)
@@ -89,25 +97,37 @@ class Validator:
 
 class String(Validator):
     errors = {
-        'type': 'Must be a string.',
-        'null': 'May not be null.',
-        'blank': 'Must not be blank.',
-        'max_length': 'Must have no more than {max_length} characters.',
-        'min_length': 'Must have at least {min_length} characters.',
-        'pattern': 'Must match the pattern /{pattern}/.',
-        'format': 'Must be a valid {format}.',
-        'enum': 'Must be a valid choice.',
-        'exact': 'Must be {exact}.'
+        "type": "Must be a string.",
+        "null": "May not be null.",
+        "blank": "Must not be blank.",
+        "max_length": "Must have no more than {max_length} characters.",
+        "min_length": "Must have at least {min_length} characters.",
+        "pattern": "Must match the pattern /{pattern}/.",
+        "format": "Must be a valid {format}.",
+        "enum": "Must be a valid choice.",
+        "exact": "Must be {exact}.",
     }
 
-    def __init__(self, max_length=None, min_length=None, pattern=None,
-                 enum=None, format=None, allow_null=False, **kwargs):
+    def __init__(
+        self,
+        max_length=None,
+        min_length=None,
+        pattern=None,
+        enum=None,
+        format=None,
+        allow_null=False,
+        **kwargs
+    ):
         super().__init__(**kwargs)
 
         assert max_length is None or isinstance(max_length, int)
         assert min_length is None or isinstance(min_length, int)
         assert pattern is None or isinstance(pattern, str)
-        assert enum is None or isinstance(enum, list) and all([isinstance(i, str) for i in enum])
+        assert (
+            enum is None
+            or isinstance(enum, list)
+            and all([isinstance(i, str) for i in enum])
+        )
         assert format is None or isinstance(format, str)
 
         self.max_length = max_length
@@ -120,33 +140,35 @@ class String(Validator):
     def validate(self, value, definitions=None, allow_coerce=False):
         if value is None and self.allow_null:
             return None
+
         elif value is None:
-            self.error('null')
+            self.error("null")
         elif self.format in FORMATS and FORMATS[self.format].is_native_type(value):
             return value
+
         elif not isinstance(value, str):
-            self.error('type')
+            self.error("type")
 
         if self.enum is not None:
             if value not in self.enum:
                 if len(self.enum) == 1:
-                    self.error('exact')
-                self.error('enum')
+                    self.error("exact")
+                self.error("enum")
 
         if self.min_length is not None:
             if len(value) < self.min_length:
                 if self.min_length == 1:
-                    self.error('blank')
+                    self.error("blank")
                 else:
-                    self.error('min_length')
+                    self.error("min_length")
 
         if self.max_length is not None:
             if len(value) > self.max_length:
-                self.error('max_length')
+                self.error("max_length")
 
         if self.pattern is not None:
             if not re.search(self.pattern, value):
-                self.error('pattern')
+                self.error("pattern")
 
         if self.format in FORMATS:
             return FORMATS[self.format].validate(value)
@@ -160,20 +182,29 @@ class NumericType(Validator):
     """
     numeric_type = None  # type: type
     errors = {
-        'type': 'Must be a number.',
-        'null': 'May not be null.',
-        'integer': 'Must be an integer.',
-        'finite': 'Must be finite.',
-        'minimum': 'Must be greater than or equal to {minimum}.',
-        'exclusive_minimum': 'Must be greater than {minimum}.',
-        'maximum': 'Must be less than or equal to {maximum}.',
-        'exclusive_maximum': 'Must be less than {maximum}.',
-        'multiple_of': 'Must be a multiple of {multiple_of}.',
+        "type": "Must be a number.",
+        "null": "May not be null.",
+        "integer": "Must be an integer.",
+        "finite": "Must be finite.",
+        "minimum": "Must be greater than or equal to {minimum}.",
+        "exclusive_minimum": "Must be greater than {minimum}.",
+        "maximum": "Must be less than or equal to {maximum}.",
+        "exclusive_maximum": "Must be less than {maximum}.",
+        "multiple_of": "Must be a multiple of {multiple_of}.",
     }
 
-    def __init__(self, minimum=None, maximum=None, exclusive_minimum=False,
-                 exclusive_maximum=False, multiple_of=None, enum=None,
-                 format=None, allow_null=False, **kwargs):
+    def __init__(
+        self,
+        minimum=None,
+        maximum=None,
+        exclusive_minimum=False,
+        exclusive_maximum=False,
+        multiple_of=None,
+        enum=None,
+        format=None,
+        allow_null=False,
+        **kwargs
+    ):
         super().__init__(**kwargs)
 
         assert minimum is None or isinstance(minimum, (int, float))
@@ -181,7 +212,11 @@ class NumericType(Validator):
         assert isinstance(exclusive_minimum, bool)
         assert isinstance(exclusive_maximum, bool)
         assert multiple_of is None or isinstance(multiple_of, (int, float))
-        assert enum is None or isinstance(enum, list) and all([isinstance(i, str) for i in enum])
+        assert (
+            enum is None
+            or isinstance(enum, list)
+            and all([isinstance(i, str) for i in enum])
+        )
         assert format is None or isinstance(format, str)
 
         self.minimum = minimum
@@ -196,51 +231,54 @@ class NumericType(Validator):
     def validate(self, value, definitions=None, allow_coerce=False):
         if value is None and self.allow_null:
             return None
+
         elif value is None:
-            self.error('null')
+            self.error("null")
         elif isinstance(value, bool):
-            self.error('type')
-        elif self.numeric_type is int and isinstance(value, float) and not value.is_integer():
-            self.error('integer')
+            self.error("type")
+        elif self.numeric_type is int and isinstance(
+            value, float
+        ) and not value.is_integer():
+            self.error("integer")
         elif not isinstance(value, (int, float)) and not allow_coerce:
-            self.error('type')
+            self.error("type")
         elif isinstance(value, float) and not isfinite(value):
-            self.error('finite')
+            self.error("finite")
 
         try:
             value = self.numeric_type(value)
         except (TypeError, ValueError):
-            self.error('type')
+            self.error("type")
 
         if self.enum is not None:
             if value not in self.enum:
                 if len(self.enum) == 1:
-                    self.error('exact')
-                self.error('enum')
+                    self.error("exact")
+                self.error("enum")
 
         if self.minimum is not None:
             if self.exclusive_minimum:
                 if value <= self.minimum:
-                    self.error('exclusive_minimum')
+                    self.error("exclusive_minimum")
             else:
                 if value < self.minimum:
-                    self.error('minimum')
+                    self.error("minimum")
 
         if self.maximum is not None:
             if self.exclusive_maximum:
                 if value >= self.maximum:
-                    self.error('exclusive_maximum')
+                    self.error("exclusive_maximum")
             else:
                 if value > self.maximum:
-                    self.error('maximum')
+                    self.error("maximum")
 
         if self.multiple_of is not None:
             if isinstance(self.multiple_of, float):
                 if not (value * (1 / self.multiple_of)).is_integer():
-                    self.error('multiple_of')
+                    self.error("multiple_of")
             else:
                 if value % self.multiple_of:
-                    self.error('multiple_of')
+                    self.error("multiple_of")
 
         return value
 
@@ -254,10 +292,7 @@ class Integer(NumericType):
 
 
 class Boolean(Validator):
-    errors = {
-        'type': 'Must be a valid boolean.',
-        'null': 'May not be null.',
-    }
+    errors = {"type": "Must be a valid boolean.", "null": "May not be null."}
 
     def __init__(self, allow_null=False, **kwargs):
         super().__init__(**kwargs)
@@ -267,33 +302,43 @@ class Boolean(Validator):
     def validate(self, value, definitions=None, allow_coerce=False):
         if value is None and self.allow_null:
             return None
+
         elif value is None:
-            self.error('null')
+            self.error("null")
         elif not isinstance(value, bool):
-            self.error('type')
+            self.error("type")
         return value
 
 
 class Object(Validator):
     errors = {
-        'type': 'Must be an object.',
-        'null': 'May not be null.',
-        'invalid_key': 'Object keys must be strings.',
-        'required': 'This field is required.',
-        'no_additional_properties': 'Unknown properties are not allowed.',
-        'empty': 'Must not be empty.',
-        'max_properties': 'Must have no more than {max_properties} properties.',
-        'min_properties': 'Must have at least {min_properties} properties.',
+        "type": "Must be an object.",
+        "null": "May not be null.",
+        "invalid_key": "Object keys must be strings.",
+        "required": "This field is required.",
+        "no_additional_properties": "Unknown properties are not allowed.",
+        "empty": "Must not be empty.",
+        "max_properties": "Must have no more than {max_properties} properties.",
+        "min_properties": "Must have at least {min_properties} properties.",
     }
 
-    def __init__(self, properties=None, pattern_properties=None,
-                 additional_properties=True, min_properties=None,
-                 max_properties=None, required=None, allow_null=False,
-                 **kwargs):
+    def __init__(
+        self,
+        properties=None,
+        pattern_properties=None,
+        additional_properties=True,
+        min_properties=None,
+        max_properties=None,
+        required=None,
+        allow_null=False,
+        **kwargs
+    ):
         super().__init__(**kwargs)
 
         properties = {} if (properties is None) else dict_type(properties)
-        pattern_properties = {} if (pattern_properties is None) else dict_type(pattern_properties)
+        pattern_properties = {} if (pattern_properties is None) else dict_type(
+            pattern_properties
+        )
         required = list(required) if isinstance(required, (list, tuple)) else required
         required = [] if (required is None) else required
 
@@ -301,7 +346,10 @@ class Object(Validator):
         assert all(isinstance(v, Validator) for v in properties.values())
         assert all(isinstance(k, str) for k in pattern_properties.keys())
         assert all(isinstance(v, Validator) for v in pattern_properties.values())
-        assert additional_properties is None or isinstance(additional_properties, (bool, Validator))
+        assert (
+            additional_properties is None
+            or isinstance(additional_properties, (bool, Validator))
+        )
         assert min_properties is None or isinstance(min_properties, int)
         assert max_properties is None or isinstance(max_properties, int)
         assert all(isinstance(i, str) for i in required)
@@ -317,10 +365,11 @@ class Object(Validator):
     def validate(self, value, definitions=None, allow_coerce=False):
         if value is None and self.allow_null:
             return None
+
         elif value is None:
-            self.error('null')
+            self.error("null")
         elif not isinstance(value, (dict, typing.Mapping)):
-            self.error('type')
+            self.error("type")
 
         definitions = self.get_definitions(definitions)
         validated = dict_type()
@@ -328,23 +377,23 @@ class Object(Validator):
         # Ensure all property keys are strings.
         errors = {}
         if any(not isinstance(key, str) for key in value.keys()):
-            self.error('invalid_key')
+            self.error("invalid_key")
 
         # Min/Max properties
         if self.min_properties is not None:
             if len(value) < self.min_properties:
                 if self.min_properties == 1:
-                    self.error('empty')
+                    self.error("empty")
                 else:
-                    self.error('min_properties')
+                    self.error("min_properties")
         if self.max_properties is not None:
             if len(value) > self.max_properties:
-                self.error('max_properties')
+                self.error("max_properties")
 
         # Required properties
         for key in self.required:
             if key not in value:
-                errors[key] = self.error_message('required')
+                errors[key] = self.error_message("required")
 
         # Properties
         for key, child_schema in self.properties.items():
@@ -352,12 +401,11 @@ class Object(Validator):
                 if child_schema.has_default():
                     validated[key] = child_schema.default
                 continue
+
             item = value[key]
             try:
                 validated[key] = child_schema.validate(
-                    item,
-                    definitions=definitions,
-                    allow_coerce=allow_coerce
+                    item, definitions=definitions, allow_coerce=allow_coerce
                 )
             except ValidationError as exc:
                 errors[key] = exc.detail
@@ -370,33 +418,27 @@ class Object(Validator):
                         item = value[key]
                         try:
                             validated[key] = child_schema.validate(
-                                item, definitions=definitions,
-                                allow_coerce=allow_coerce
+                                item, definitions=definitions, allow_coerce=allow_coerce
                             )
                         except ValidationError as exc:
                             errors[key] = exc.detail
 
         # Additional properties
-        remaining = [
-            key for key in value.keys()
-            if key not in set(validated.keys())
-        ]
+        remaining = [key for key in value.keys() if key not in set(validated.keys())]
 
         if self.additional_properties is True:
             for key in remaining:
                 validated[key] = value[key]
         elif self.additional_properties is False:
             for key in remaining:
-                errors[key] = self.error_message('no_additional_properties')
+                errors[key] = self.error_message("no_additional_properties")
         elif self.additional_properties is not None:
             child_schema = self.additional_properties
             for key in remaining:
                 item = value[key]
                 try:
                     validated[key] = child_schema.validate(
-                        item,
-                        definitions=definitions,
-                        allow_coerce=allow_coerce
+                        item, definitions=definitions, allow_coerce=allow_coerce
                     )
                 except ValidationError as exc:
                     errors[key] = exc.detail
@@ -409,27 +451,40 @@ class Object(Validator):
 
 class Array(Validator):
     errors = {
-        'type': 'Must be an array.',
-        'null': 'May not be null.',
-        'empty': 'Must not be empty.',
-        'exact_items': 'Must have {min_items} items.',
-        'min_items': 'Must have at least {min_items} items.',
-        'max_items': 'Must have no more than {max_items} items.',
-        'additional_items': 'May not contain additional items.',
-        'unique_items': 'This item is not unique.',
+        "type": "Must be an array.",
+        "null": "May not be null.",
+        "empty": "Must not be empty.",
+        "exact_items": "Must have {min_items} items.",
+        "min_items": "Must have at least {min_items} items.",
+        "max_items": "Must have no more than {max_items} items.",
+        "additional_items": "May not contain additional items.",
+        "unique_items": "This item is not unique.",
     }
 
-    def __init__(self, items=None, additional_items=None, min_items=None,
-                 max_items=None, unique_items=False, allow_null=False, **kwargs):
+    def __init__(
+        self,
+        items=None,
+        additional_items=None,
+        min_items=None,
+        max_items=None,
+        unique_items=False,
+        allow_null=False,
+        **kwargs
+    ):
         super().__init__(**kwargs)
 
         items = list(items) if isinstance(items, (list, tuple)) else items
 
-        assert items is None or isinstance(items, Validator) or (
-            isinstance(items, list) and
-            all(isinstance(i, Validator) for i in items)
+        assert (
+            items is None
+            or isinstance(items, Validator)
+            or (
+                isinstance(items, list) and all(isinstance(i, Validator) for i in items)
+            )
         )
-        assert additional_items is None or isinstance(additional_items, (bool, Validator))
+        assert (
+            additional_items is None or isinstance(additional_items, (bool, Validator))
+        )
         assert min_items is None or isinstance(min_items, int)
         assert max_items is None or isinstance(max_items, int)
         assert isinstance(unique_items, bool)
@@ -444,24 +499,33 @@ class Array(Validator):
     def validate(self, value, definitions=None, allow_coerce=False):
         if value is None and self.allow_null:
             return None
+
         elif value is None:
-            self.error('null')
+            self.error("null")
         elif not isinstance(value, list):
-            self.error('type')
+            self.error("type")
 
         definitions = self.get_definitions(definitions)
         validated = []
 
-        if self.min_items is not None and self.min_items == self.max_items and len(value) != self.min_items:
-            self.error('exact_items')
+        if (
+            self.min_items is not None
+            and self.min_items == self.max_items
+            and len(value) != self.min_items
+        ):
+            self.error("exact_items")
         if self.min_items is not None and len(value) < self.min_items:
             if self.min_items == 1:
-                self.error('empty')
-            self.error('min_items')
+                self.error("empty")
+            self.error("min_items")
         elif self.max_items is not None and len(value) > self.max_items:
-            self.error('max_items')
-        elif isinstance(self.items, list) and (self.additional_items is False) and len(value) > len(self.items):
-            self.error('additional_items')
+            self.error("max_items")
+        elif isinstance(self.items, list) and (self.additional_items is False) and len(
+            value
+        ) > len(
+            self.items
+        ):
+            self.error("additional_items")
 
         # Ensure all items are of the right type.
         errors = {}
@@ -473,26 +537,20 @@ class Array(Validator):
                 if isinstance(self.items, list):
                     if pos < len(self.items):
                         item = self.items[pos].validate(
-                            item,
-                            definitions=definitions,
-                            allow_coerce=allow_coerce
+                            item, definitions=definitions, allow_coerce=allow_coerce
                         )
                     elif isinstance(self.additional_items, Validator):
                         item = self.additional_items.validate(
-                            item,
-                            definitions=definitions,
-                            allow_coerce=allow_coerce
+                            item, definitions=definitions, allow_coerce=allow_coerce
                         )
                 elif self.items is not None:
                     item = self.items.validate(
-                        item,
-                        definitions=definitions,
-                        allow_coerce=allow_coerce
+                        item, definitions=definitions, allow_coerce=allow_coerce
                     )
 
                 if self.unique_items:
                     if item in seen_items:
-                        self.error('unique_items')
+                        self.error("unique_items")
                     else:
                         seen_items.add(item)
 
@@ -507,21 +565,25 @@ class Array(Validator):
 
 
 class Date(String):
+
     def __init__(self, **kwargs):
-        super().__init__(format='date', **kwargs)
+        super().__init__(format="date", **kwargs)
 
 
 class Time(String):
+
     def __init__(self, **kwargs):
-        super().__init__(format='time', **kwargs)
+        super().__init__(format="time", **kwargs)
 
 
 class DateTime(String):
+
     def __init__(self, **kwargs):
-        super().__init__(format='datetime', **kwargs)
+        super().__init__(format="datetime", **kwargs)
 
 
 class Any(Validator):
+
     def validate(self, value, definitions=None, allow_coerce=False):
         # TODO: Validate value matches primitive types
         return value
@@ -529,8 +591,7 @@ class Any(Validator):
 
 class Union(Validator):
     errors = {
-        'null': 'Must not be null.',
-        'union': 'Must match one of the union types.'
+        "null": "Must not be null.", "union": "Must match one of the union types."
     }
 
     def __init__(self, items, allow_null=False):
@@ -541,36 +602,35 @@ class Union(Validator):
     def validate(self, value, definitions=None, allow_coerce=False):
         if value is None and self.allow_null:
             return None
+
         elif value is None:
-            self.error('null')
+            self.error("null")
 
         for item in self.items:
             try:
                 return item.validate(
-                    value,
-                    definitions=definitions,
-                    allow_coerce=allow_coerce
+                    value, definitions=definitions, allow_coerce=allow_coerce
                 )
+
             except ValidationError:
                 pass
-        self.error('union')
+        self.error("union")
 
 
 class Ref(Validator):
+
     def __init__(self, ref, **kwargs):
         super().__init__(**kwargs)
         assert isinstance(ref, str)
         self.ref = ref
 
     def validate(self, value, definitions=None, allow_coerce=False):
-        assert definitions is not None, 'Ref.validate() requires definitions'
+        assert definitions is not None, "Ref.validate() requires definitions"
         assert self.ref in definitions, 'Ref "%s" not in definitions' % self.ref
 
         child_schema = definitions[self.ref]
         return child_schema.validate(
-            value,
-            definitions=definitions,
-            allow_coerce=allow_coerce
+            value, definitions=definitions, allow_coerce=allow_coerce
         )
 
 
@@ -602,23 +662,33 @@ class Uniqueness():
         """
 
         # Only primitive types can be handled.
-        assert (element is None) or isinstance(element, (bool, int, float, str, list, dict))
+        assert (
+            (element is None)
+            or isinstance(element, (bool, int, float, str, list, dict))
+        )
 
         if element is True:
             # Need to make `True` distinct from `1`.
             return self.TRUE
+
         elif element is False:
             # Need to make `False` distinct from `0`.
             return self.FALSE
+
         elif isinstance(element, list):
             # Represent lists using a two-tuple of ('list', (item, item, ...))
-            return ('list', tuple([
-                self.make_hashable(item) for item in element
-            ]))
+            return ("list", tuple([self.make_hashable(item) for item in element]))
+
         elif isinstance(element, dict):
             # Represent dicts using a two-tuple of ('dict', ((key, val), (key, val), ...))
-            return ('dict', tuple([
-                (self.make_hashable(key), self.make_hashable(value)) for key, value in element.items()
-            ]))
+            return (
+                "dict",
+                tuple(
+                    [
+                        (self.make_hashable(key), self.make_hashable(value))
+                        for key, value in element.items()
+                    ]
+                ),
+            )
 
         return element

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def get_version(package):
     """
     Return package version as listed in `__version__` in `init.py`.
     """
-    init_py = open(os.path.join(package, '__init__.py')).read()
+    init_py = open(os.path.join(package, "__init__.py")).read()
     return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
 
 
@@ -20,9 +20,11 @@ def get_packages(package):
     """
     Return root package and all sub-packages.
     """
-    return [dirpath
-            for dirpath, dirnames, filenames in os.walk(package)
-            if os.path.exists(os.path.join(dirpath, '__init__.py'))]
+    return [
+        dirpath
+        for dirpath, dirnames, filenames in os.walk(package)
+        if os.path.exists(os.path.join(dirpath, "__init__.py"))
+    ]
 
 
 def get_package_data(package):
@@ -30,45 +32,41 @@ def get_package_data(package):
     Return all files under the root package, that are not in a
     package themselves.
     """
-    walk = [(dirpath.replace(package + os.sep, '', 1), filenames)
-            for dirpath, dirnames, filenames in os.walk(package)
-            if not os.path.exists(os.path.join(dirpath, '__init__.py'))]
+    walk = [
+        (dirpath.replace(package + os.sep, "", 1), filenames)
+        for dirpath, dirnames, filenames in os.walk(package)
+        if not os.path.exists(os.path.join(dirpath, "__init__.py"))
+    ]
 
     filepaths = []
     for base, filenames in walk:
-        filepaths.extend([os.path.join(base, filename)
-                          for filename in filenames])
+        filepaths.extend([os.path.join(base, filename) for filename in filenames])
     return {package: filepaths}
 
 
-version = get_version('apistar')
+version = get_version("apistar")
 
 
 setup(
-    name='apistar',
+    name="apistar",
     version=version,
-    url='http://www.encode.io/apistar/',
-    license='BSD',
-    description='Blazingly fast & beautifully expressive Web APIs',
-    author='Tom Christie',
-    author_email='tom@tomchristie.com',
-    packages=get_packages('apistar'),
-    package_data=get_package_data('apistar'),
-    install_requires=[
-        'jinja2',
-        'requests',
-        'werkzeug',
-        'whitenoise'
-    ],
+    url="http://www.encode.io/apistar/",
+    license="BSD",
+    description="Blazingly fast & beautifully expressive Web APIs",
+    author="Tom Christie",
+    author_email="tom@tomchristie.com",
+    packages=get_packages("apistar"),
+    package_data=get_package_data("apistar"),
+    install_requires=["jinja2", "requests", "werkzeug", "whitenoise"],
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Environment :: Web Environment',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: OS Independent',
-        'Topic :: Internet :: WWW/HTTP',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        "Development Status :: 3 - Alpha",
+        "Environment :: Web Environment",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: OS Independent",
+        "Topic :: Internet :: WWW/HTTP",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
     ],
 )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,7 +13,7 @@ from apistar import (
     Section,
     TestClient,
     exceptions,
-    http,
+    http
 )
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,134 +3,193 @@ import os
 import pytest
 
 from apistar import (
-    App, Client, Document, Field, Include, Link, Route, Section, TestClient,
-    exceptions, http
+    App,
+    Client,
+    Document,
+    Field,
+    Include,
+    Link,
+    Route,
+    Section,
+    TestClient,
+    exceptions,
+    http,
 )
 
 
 def no_parameter():
-    return http.JSONResponse({'hello': 'world'})
+    return http.JSONResponse({"hello": "world"})
 
 
 def query_parameter(params: http.QueryParams):
-    return http.JSONResponse({'params': dict(params)})
+    return http.JSONResponse({"params": dict(params)})
 
 
 def body_parameter(data: http.RequestData):
-    return http.JSONResponse({'data': data})
+    return http.JSONResponse({"data": data})
 
 
 def text_response():
-    return http.HTMLResponse('Hello, world!')
+    return http.HTMLResponse("Hello, world!")
 
 
 def empty_response():
-    return http.Response(content=b'', status_code=204)
+    return http.Response(content=b"", status_code=204)
 
 
 def error_response():
-    return http.JSONResponse({'error': 'failed'}, status_code=400)
+    return http.JSONResponse({"error": "failed"}, status_code=400)
 
 
 def download_response():
-    return http.Response(b'...', headers={
-        'Content-Type': 'image/jpeg',
-        'Content-Disposition': 'attachment; filename=example.jpg;'
-    })
+    return http.Response(
+        b"...",
+        headers={
+            "Content-Type": "image/jpeg",
+            "Content-Disposition": "attachment; filename=example.jpg;",
+        },
+    )
 
 
 def download_response_filename_in_url():
-    return http.Response(b'...', headers={
-        'Content-Type': 'image/jpeg'
-    })
+    return http.Response(b"...", headers={"Content-Type": "image/jpeg"})
 
 
 routes = [
-    Include(url='/parameters', name='parameters', routes=[
-        Route(url='/no-parameters/', method='GET', handler=no_parameter),
-        Route(url='/query-parameter/', method='GET', handler=query_parameter),
-        Route(url='/body-parameter/', method='POST', handler=body_parameter),
-    ]),
-    Include(url='/responses', name='responses', routes=[
-        Route(url='/text-response/', method='GET', handler=text_response),
-        Route(url='/empty-response/', method='GET', handler=empty_response),
-        Route(url='/error-response/', method='GET', handler=error_response),
-    ]),
-    Include(url='/downloads', name='downloads', routes=[
-        Route(url='/download-response/', method='GET', handler=download_response),
-        Route(url='/download-response/path.jpg', method='GET', handler=download_response_filename_in_url),
-    ]),
+    Include(
+        url="/parameters",
+        name="parameters",
+        routes=[
+            Route(url="/no-parameters/", method="GET", handler=no_parameter),
+            Route(url="/query-parameter/", method="GET", handler=query_parameter),
+            Route(url="/body-parameter/", method="POST", handler=body_parameter),
+        ],
+    ),
+    Include(
+        url="/responses",
+        name="responses",
+        routes=[
+            Route(url="/text-response/", method="GET", handler=text_response),
+            Route(url="/empty-response/", method="GET", handler=empty_response),
+            Route(url="/error-response/", method="GET", handler=error_response),
+        ],
+    ),
+    Include(
+        url="/downloads",
+        name="downloads",
+        routes=[
+            Route(url="/download-response/", method="GET", handler=download_response),
+            Route(
+                url="/download-response/path.jpg",
+                method="GET",
+                handler=download_response_filename_in_url,
+            ),
+        ],
+    ),
 ]
 app = App(routes=routes)
 
 
 document = Document(
-    url='http://testserver',
+    url="http://testserver",
     content=[
-        Section(name='parameters', content=[
-            Link(name='no_parameter', url='/parameters/no-parameters/', method='GET'),
-            Link(name='query_parameter', url='/parameters/query-parameter/', method='GET', fields=[
-                Field(name='a', location='query')
-            ]),
-            Link(
-                name='body_parameter',
-                url='/parameters/body-parameter/',
-                method='POST',
-                encoding='application/json',
-                fields=[
-                    Field(name='a', location='body')
-                ]
-            )
-        ]),
-        Section(name='responses', content=[
-            Link(name='text_response', url='/responses/text-response/', method='GET'),
-            Link(name='empty_response', url='/responses/empty-response/', method='GET'),
-            Link(name='error_response', url='/responses/error-response/', method='GET')
-        ]),
-        Section(name='downloads', content=[
-            Link(name='download_response', url='/downloads/download-response/', method='GET'),
-            Link(name='download_response_filename_in_url', url='/downloads/download-response/path.jpg', method='GET'),
-        ]),
-    ]
+        Section(
+            name="parameters",
+            content=[
+                Link(
+                    name="no_parameter", url="/parameters/no-parameters/", method="GET"
+                ),
+                Link(
+                    name="query_parameter",
+                    url="/parameters/query-parameter/",
+                    method="GET",
+                    fields=[Field(name="a", location="query")],
+                ),
+                Link(
+                    name="body_parameter",
+                    url="/parameters/body-parameter/",
+                    method="POST",
+                    encoding="application/json",
+                    fields=[Field(name="a", location="body")],
+                ),
+            ],
+        ),
+        Section(
+            name="responses",
+            content=[
+                Link(
+                    name="text_response", url="/responses/text-response/", method="GET"
+                ),
+                Link(
+                    name="empty_response",
+                    url="/responses/empty-response/",
+                    method="GET",
+                ),
+                Link(
+                    name="error_response",
+                    url="/responses/error-response/",
+                    method="GET",
+                ),
+            ],
+        ),
+        Section(
+            name="downloads",
+            content=[
+                Link(
+                    name="download_response",
+                    url="/downloads/download-response/",
+                    method="GET",
+                ),
+                Link(
+                    name="download_response_filename_in_url",
+                    url="/downloads/download-response/path.jpg",
+                    method="GET",
+                ),
+            ],
+        ),
+    ],
 )
 session = TestClient(app)
 client = Client(document=document, session=session)
 
 
 def test_no_parameters():
-    assert client.request('parameters:no_parameter') == {'hello': 'world'}
+    assert client.request("parameters:no_parameter") == {"hello": "world"}
 
 
 def test_query_parameter():
-    assert client.request('parameters:query_parameter', a=1) == {'params': {'a': '1'}}
+    assert client.request("parameters:query_parameter", a=1) == {"params": {"a": "1"}}
 
 
 def test_body_parameter():
-    assert client.request('parameters:body_parameter', a={'abc': 123}) == {'data': {'abc': 123}}
+    assert (
+        client.request("parameters:body_parameter", a={"abc": 123})
+        == {"data": {"abc": 123}}
+    )
 
 
 def test_text_response():
-    assert client.request('responses:text_response') == 'Hello, world!'
+    assert client.request("responses:text_response") == "Hello, world!"
 
 
 def test_empty_response():
-    assert client.request('responses:empty_response') is None
+    assert client.request("responses:empty_response") is None
 
 
 def test_error_response():
     with pytest.raises(exceptions.ErrorResponse) as exc:
-        client.request('responses:error_response')
-    assert exc.value.title == '400 Bad Request'
-    assert exc.value.content == {'error': 'failed'}
+        client.request("responses:error_response")
+    assert exc.value.title == "400 Bad Request"
+    assert exc.value.content == {"error": "failed"}
 
 
 def test_download_response():
-    downloaded = client.request('downloads:download_response')
-    assert downloaded.read() == b'...'
-    assert os.path.basename(downloaded.name) == 'example.jpg'
+    downloaded = client.request("downloads:download_response")
+    assert downloaded.read() == b"..."
+    assert os.path.basename(downloaded.name) == "example.jpg"
 
 
 def test_download_response_filename_in_url():
-    downloaded = client.request('downloads:download_response_filename_in_url')
-    assert downloaded.read() == b'...'
-    assert os.path.basename(downloaded.name) == 'path.jpg'
+    downloaded = client.request("downloads:download_response_filename_in_url")
+    assert downloaded.read() == b"..."
+    assert os.path.basename(downloaded.name) == "path.jpg"

--- a/tests/test_event_hooks.py
+++ b/tests/test_event_hooks.py
@@ -2,17 +2,18 @@ from apistar import App, Route, exceptions, http, test
 
 
 class CustomResponseHeader():
+
     def on_response(self, response: http.Response):
-        response.headers['Custom'] = 'Ran on_response'
+        response.headers["Custom"] = "Ran on_response"
         return response
 
     def on_error(self, response: http.Response):
-        response.headers['Custom'] = 'Ran on_error'
+        response.headers["Custom"] = "Ran on_error"
         return response
 
 
 def hello_world():
-    return {'hello': 'world'}
+    return {"hello": "world"}
 
 
 def error():
@@ -20,8 +21,8 @@ def error():
 
 
 routes = [
-    Route('/hello', method='GET', handler=hello_world),
-    Route('/error', method='GET', handler=error),
+    Route("/hello", method="GET", handler=hello_world),
+    Route("/error", method="GET", handler=error),
 ]
 
 event_hooks = [CustomResponseHeader()]
@@ -32,12 +33,12 @@ client = test.TestClient(app)
 
 
 def test_on_response():
-    response = client.get('/hello')
+    response = client.get("/hello")
     assert response.status_code == 200
-    assert response.headers['Custom'] == 'Ran on_response'
+    assert response.headers["Custom"] == "Ran on_response"
 
 
 def test_on_error():
-    response = client.get('/error')
+    response = client.get("/error")
     assert response.status_code == 400
-    assert response.headers['Custom'] == 'Ran on_error'
+    assert response.headers["Custom"] == "Ran on_error"

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -8,115 +8,101 @@ UTC = datetime.timezone.utc
 
 
 def test_date():
+
     class Example(types.Type):
         when = validators.Date()
 
-    example = Example({
-        'when': '2020-01-01'
-    })
+    example = Example({"when": "2020-01-01"})
     assert example.when == datetime.date(2020, 1, 1)
-    assert example['when'] == '2020-01-01'
+    assert example["when"] == "2020-01-01"
 
-    example = Example({
-        'when': datetime.date(2020, 1, 1)
-    })
+    example = Example({"when": datetime.date(2020, 1, 1)})
     assert example.when == datetime.date(2020, 1, 1)
-    assert example['when'] == '2020-01-01'
+    assert example["when"] == "2020-01-01"
 
     with pytest.raises(exceptions.ValidationError) as exc:
-        Example({'when': 'abc'})
-    assert exc.value.detail == {'when': 'Must be a valid date.'}
+        Example({"when": "abc"})
+    assert exc.value.detail == {"when": "Must be a valid date."}
 
     with pytest.raises(exceptions.ValidationError) as exc:
-        Example({'when': None})
-    assert exc.value.detail == {'when': 'May not be null.'}
+        Example({"when": None})
+    assert exc.value.detail == {"when": "May not be null."}
 
 
 def test_nullable_date():
+
     class Example(types.Type):
         when = validators.Date(allow_null=True)
 
-    example = Example({
-        'when': None
-    })
+    example = Example({"when": None})
     assert example.when is None
-    assert example['when'] is None
+    assert example["when"] is None
 
 
 def test_time():
+
     class Example(types.Type):
         when = validators.Time()
 
-    example = Example({
-        'when': '12:00:00'
-    })
+    example = Example({"when": "12:00:00"})
     assert example.when == datetime.time(12, 0, 0)
-    assert example['when'] == '12:00:00'
+    assert example["when"] == "12:00:00"
 
-    example = Example({
-        'when': datetime.time(12, 0, 0)
-    })
+    example = Example({"when": datetime.time(12, 0, 0)})
     assert example.when == datetime.time(12, 0, 0)
-    assert example['when'] == '12:00:00'
+    assert example["when"] == "12:00:00"
 
     with pytest.raises(exceptions.ValidationError) as exc:
-        Example({'when': 'abc'})
-    assert exc.value.detail == {'when': 'Must be a valid time.'}
+        Example({"when": "abc"})
+    assert exc.value.detail == {"when": "Must be a valid time."}
 
     with pytest.raises(exceptions.ValidationError) as exc:
-        Example({'when': None})
-    assert exc.value.detail == {'when': 'May not be null.'}
+        Example({"when": None})
+    assert exc.value.detail == {"when": "May not be null."}
 
 
 def test_nullable_time():
+
     class Example(types.Type):
         when = validators.Time(allow_null=True)
 
-    example = Example({
-        'when': None
-    })
+    example = Example({"when": None})
     assert example.when is None
-    assert example['when'] is None
+    assert example["when"] is None
 
 
 def test_datetime():
+
     class Example(types.Type):
         when = validators.DateTime()
 
-    example = Example({
-        'when': '2020-01-01T12:00:00Z'
-    })
+    example = Example({"when": "2020-01-01T12:00:00Z"})
     assert example.when == datetime.datetime(2020, 1, 1, 12, 0, 0, tzinfo=UTC)
-    assert example['when'] == '2020-01-01T12:00:00Z'
+    assert example["when"] == "2020-01-01T12:00:00Z"
 
-    example = Example({
-        'when': datetime.datetime(2020, 1, 1, 12, 0, 0, tzinfo=UTC)
-    })
+    example = Example({"when": datetime.datetime(2020, 1, 1, 12, 0, 0, tzinfo=UTC)})
     assert example.when == datetime.datetime(2020, 1, 1, 12, 0, 0, tzinfo=UTC)
-    assert example['when'] == '2020-01-01T12:00:00Z'
+    assert example["when"] == "2020-01-01T12:00:00Z"
 
     with pytest.raises(exceptions.ValidationError) as exc:
-        Example({'when': 'abc'})
-    assert exc.value.detail == {'when': 'Must be a valid datetime.'}
+        Example({"when": "abc"})
+    assert exc.value.detail == {"when": "Must be a valid datetime."}
 
     with pytest.raises(exceptions.ValidationError) as exc:
-        Example({'when': None})
-    assert exc.value.detail == {'when': 'May not be null.'}
+        Example({"when": None})
+    assert exc.value.detail == {"when": "May not be null."}
 
-    example = Example({
-        'when': '2020-01-01T12:00:00-02:00'
-    })
+    example = Example({"when": "2020-01-01T12:00:00-02:00"})
     tzinfo = datetime.timezone(-datetime.timedelta(hours=2))
     assert example.when == datetime.datetime(2020, 1, 1, 12, 0, 0, tzinfo=tzinfo)
-    assert example['when'] == '2020-01-01T12:00:00-02:00'
+    assert example["when"] == "2020-01-01T12:00:00-02:00"
 
 
 def test_nullable_datetime():
+
     class Example(types.Type):
         when = validators.DateTime(allow_null=True)
 
-    example = Example({
-        'when': None
-    })
+    example = Example({"when": None})
     assert example.when is None
-    assert example['when'] is None
+    assert example["when"] is None

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -8,99 +8,101 @@ from apistar.server.app import App, ASyncApp
 
 def get_request(request: http.Request):
     return {
-        'method': request.method,
-        'url': request.url,
-        'headers': dict(request.headers),
-        'body': request.body.decode('utf-8')
+        "method": request.method,
+        "url": request.url,
+        "headers": dict(request.headers),
+        "body": request.body.decode("utf-8"),
     }
 
 
 def get_method(method: http.Method):
-    return {'method': method}
+    return {"method": method}
 
 
 def get_scheme(scheme: http.Scheme):
-    return {'scheme': scheme}
+    return {"scheme": scheme}
 
 
 def get_host(host: http.Host):
-    return {'host': host}
+    return {"host": host}
 
 
 def get_port(port: http.Port):
-    return {'port': port}
+    return {"port": port}
 
 
 def get_path(path: http.Path):
-    return {'path': path}
+    return {"path": path}
 
 
 def get_query_string(query_string: http.QueryString):
-    return {'query_string': query_string}
+    return {"query_string": query_string}
 
 
 def get_query_params(query_string: http.QueryString, query_params: http.QueryParams):
-    return {'query_params': dict(query_params)}
+    return {"query_params": dict(query_params)}
 
 
 def get_page_query_param(page: http.QueryParam):
-    return {'page': page}
+    return {"page": page}
 
 
 def get_url(url: http.URL):
-    return {'url': url, 'url.components': url.components}
+    return {"url": url, "url.components": url.components}
 
 
 def get_body(body: http.Body):
-    return {'body': body.decode('utf-8')}
+    return {"body": body.decode("utf-8")}
 
 
 def get_headers(headers: http.Headers):
-    return {'headers': dict(headers)}
+    return {"headers": dict(headers)}
 
 
 def get_accept_header(accept: http.Header):
-    return {'accept': accept}
+    return {"accept": accept}
 
 
 def get_missing_header(missing: http.Header):
-    return {'missing': missing}
+    return {"missing": missing}
 
 
 def get_path_params(params: http.PathParams):
-    return {'params': params}
+    return {"params": params}
 
 
 def get_request_data(data: http.RequestData):
-    return {'data': data}
+    return {"data": data}
 
 
 routes = [
-    Route('/request/', 'GET', get_request),
-    Route('/method/', 'GET', get_method),
-    Route('/method/', 'POST', get_method, name='post_method'),
-    Route('/scheme/', 'GET', get_scheme),
-    Route('/host/', 'GET', get_host),
-    Route('/port/', 'GET', get_port),
-    Route('/path/', 'GET', get_path),
-    Route('/query_string/', 'GET', get_query_string),
-    Route('/query_params/', 'GET', get_query_params),
-    Route('/page_query_param/', 'GET', get_page_query_param),
-    Route('/url/', 'GET', get_url),
-    Route('/body/', 'POST', get_body),
-    Route('/headers/', 'GET', get_headers),
-    Route('/headers/', 'POST', get_headers, name='post_headers'),
-    Route('/accept_header/', 'GET', get_accept_header),
-    Route('/missing_header/', 'GET', get_missing_header),
-    Route('/path_params/{example}/', 'GET', get_path_params),
-    Route('/full_path_params/{+example}', 'GET', get_path_params, name='full_path_params'),
-    Route('/request_data/', 'POST', get_request_data),
+    Route("/request/", "GET", get_request),
+    Route("/method/", "GET", get_method),
+    Route("/method/", "POST", get_method, name="post_method"),
+    Route("/scheme/", "GET", get_scheme),
+    Route("/host/", "GET", get_host),
+    Route("/port/", "GET", get_port),
+    Route("/path/", "GET", get_path),
+    Route("/query_string/", "GET", get_query_string),
+    Route("/query_params/", "GET", get_query_params),
+    Route("/page_query_param/", "GET", get_page_query_param),
+    Route("/url/", "GET", get_url),
+    Route("/body/", "POST", get_body),
+    Route("/headers/", "GET", get_headers),
+    Route("/headers/", "POST", get_headers, name="post_headers"),
+    Route("/accept_header/", "GET", get_accept_header),
+    Route("/missing_header/", "GET", get_missing_header),
+    Route("/path_params/{example}/", "GET", get_path_params),
+    Route(
+        "/full_path_params/{+example}", "GET", get_path_params, name="full_path_params"
+    ),
+    Route("/request_data/", "POST", get_request_data),
 ]
 
 
-@pytest.fixture(scope='module', params=['wsgi', 'asgi'])
+@pytest.fixture(scope="module", params=["wsgi", "asgi"])
 def client(request):
-    if request.param == 'asgi':
+    if request.param == "asgi":
         app = ASyncApp(routes=routes)
     else:
         app = App(routes=routes)
@@ -108,219 +110,260 @@ def client(request):
 
 
 def test_request(client):
-    response = client.get('/request/')
-    assert response.json() == {
-        'method': 'GET',
-        'url': 'http://testserver/request/',
-        'headers': {
-            'accept': '*/*',
-            'accept-encoding': 'gzip, deflate',
-            'connection': 'keep-alive',
-            'host': 'testserver',
-            'user-agent': 'testclient'
-        },
-        'body': ''
-    }
+    response = client.get("/request/")
+    assert (
+        response.json()
+        == {
+            "method": "GET",
+            "url": "http://testserver/request/",
+            "headers": {
+                "accept": "*/*",
+                "accept-encoding": "gzip, deflate",
+                "connection": "keep-alive",
+                "host": "testserver",
+                "user-agent": "testclient",
+            },
+            "body": "",
+        }
+    )
 
 
 def test_method(client):
-    response = client.get('/method/')
-    assert response.json() == {'method': 'GET'}
-    response = client.post('/method/')
-    assert response.json() == {'method': 'POST'}
+    response = client.get("/method/")
+    assert response.json() == {"method": "GET"}
+    response = client.post("/method/")
+    assert response.json() == {"method": "POST"}
 
 
 def test_scheme(client):
-    response = client.get('http://example.com/scheme/')
-    assert response.json() == {'scheme': 'http'}
-    response = client.get('https://example.com/scheme/')
-    assert response.json() == {'scheme': 'https'}
+    response = client.get("http://example.com/scheme/")
+    assert response.json() == {"scheme": "http"}
+    response = client.get("https://example.com/scheme/")
+    assert response.json() == {"scheme": "https"}
 
 
 def test_host(client):
-    response = client.get('http://example.com/host/')
-    assert response.json() == {'host': 'example.com'}
+    response = client.get("http://example.com/host/")
+    assert response.json() == {"host": "example.com"}
 
 
 def test_port(client):
-    response = client.get('http://example.com/port/')
-    assert response.json() == {'port': 80}
-    response = client.get('https://example.com/port/')
-    assert response.json() == {'port': 443}
-    response = client.get('http://example.com:123/port/')
-    assert response.json() == {'port': 123}
-    response = client.get('https://example.com:123/port/')
-    assert response.json() == {'port': 123}
+    response = client.get("http://example.com/port/")
+    assert response.json() == {"port": 80}
+    response = client.get("https://example.com/port/")
+    assert response.json() == {"port": 443}
+    response = client.get("http://example.com:123/port/")
+    assert response.json() == {"port": 123}
+    response = client.get("https://example.com:123/port/")
+    assert response.json() == {"port": 123}
 
 
 def test_path(client):
-    response = client.get('/path/')
-    assert response.json() == {'path': '/path/'}
+    response = client.get("/path/")
+    assert response.json() == {"path": "/path/"}
 
 
 def test_query_string(client):
-    response = client.get('/query_string/')
-    assert response.json() == {'query_string': ''}
-    response = client.get('/query_string/?a=1&a=2&b=3')
-    assert response.json() == {'query_string': 'a=1&a=2&b=3'}
+    response = client.get("/query_string/")
+    assert response.json() == {"query_string": ""}
+    response = client.get("/query_string/?a=1&a=2&b=3")
+    assert response.json() == {"query_string": "a=1&a=2&b=3"}
 
 
 def test_query_params(client):
-    response = client.get('/query_params/')
-    assert response.json() == {'query_params': {}}
-    response = client.get('/query_params/?a=1&a=2&b=3')
-    assert response.json() == {
-        'query_params': {'a': '1', 'b': '3'}
-    }
+    response = client.get("/query_params/")
+    assert response.json() == {"query_params": {}}
+    response = client.get("/query_params/?a=1&a=2&b=3")
+    assert response.json() == {"query_params": {"a": "1", "b": "3"}}
 
 
 def test_single_query_param(client):
-    response = client.get('/page_query_param/')
-    assert response.json() == {'page': None}
-    response = client.get('/page_query_param/?page=123')
-    assert response.json() == {'page': '123'}
-    response = client.get('/page_query_param/?page=123&page=456')
-    assert response.json() == {'page': '123'}
+    response = client.get("/page_query_param/")
+    assert response.json() == {"page": None}
+    response = client.get("/page_query_param/?page=123")
+    assert response.json() == {"page": "123"}
+    response = client.get("/page_query_param/?page=123&page=456")
+    assert response.json() == {"page": "123"}
 
 
 def test_url(client):
-    response = client.get('http://example.com/url/')
-    assert response.json() == {
-        'url': 'http://example.com/url/',
-        'url.components': ['http', 'example.com', '/url/', '', '', '']
-    }
-    response = client.get('https://example.com/url/')
-    assert response.json() == {
-        'url': 'https://example.com/url/',
-        'url.components': ['https', 'example.com', '/url/', '', '', '']
-    }
-    response = client.get('http://example.com:123/url/')
-    assert response.json() == {
-        'url': 'http://example.com:123/url/',
-        'url.components': ['http', 'example.com:123', '/url/', '', '', '']
-    }
-    response = client.get('https://example.com:123/url/')
-    assert response.json() == {
-        'url': 'https://example.com:123/url/',
-        'url.components': ['https', 'example.com:123', '/url/', '', '', '']
-    }
-    response = client.get('http://example.com/url/?a=1')
-    assert response.json() == {
-        'url': 'http://example.com/url/?a=1',
-        'url.components': ['http', 'example.com', '/url/', '', 'a=1', '']
-    }
+    response = client.get("http://example.com/url/")
+    assert (
+        response.json()
+        == {
+            "url": "http://example.com/url/",
+            "url.components": ["http", "example.com", "/url/", "", "", ""],
+        }
+    )
+    response = client.get("https://example.com/url/")
+    assert (
+        response.json()
+        == {
+            "url": "https://example.com/url/",
+            "url.components": ["https", "example.com", "/url/", "", "", ""],
+        }
+    )
+    response = client.get("http://example.com:123/url/")
+    assert (
+        response.json()
+        == {
+            "url": "http://example.com:123/url/",
+            "url.components": ["http", "example.com:123", "/url/", "", "", ""],
+        }
+    )
+    response = client.get("https://example.com:123/url/")
+    assert (
+        response.json()
+        == {
+            "url": "https://example.com:123/url/",
+            "url.components": ["https", "example.com:123", "/url/", "", "", ""],
+        }
+    )
+    response = client.get("http://example.com/url/?a=1")
+    assert (
+        response.json()
+        == {
+            "url": "http://example.com/url/?a=1",
+            "url.components": ["http", "example.com", "/url/", "", "a=1", ""],
+        }
+    )
 
 
 def test_body(client):
-    response = client.post('/body/', data="content")
-    assert response.json() == {'body': 'content'}
+    response = client.post("/body/", data="content")
+    assert response.json() == {"body": "content"}
 
 
 def test_headers(client):
-    response = client.get('http://example.com/headers/')
-    assert response.json() == {'headers': {
-        'accept': '*/*',
-        'accept-encoding': 'gzip, deflate',
-        'connection': 'keep-alive',
-        'host': 'example.com',
-        'user-agent': 'testclient'
-    }}
-    response = client.get('http://example.com/headers/', headers={
-        'X-Example-Header': 'example'
-    })
-    assert response.json() == {'headers': {
-        'accept': '*/*',
-        'accept-encoding': 'gzip, deflate',
-        'connection': 'keep-alive',
-        'host': 'example.com',
-        'user-agent': 'testclient',
-        'x-example-header': 'example'
-    }}
+    response = client.get("http://example.com/headers/")
+    assert (
+        response.json()
+        == {
+            "headers": {
+                "accept": "*/*",
+                "accept-encoding": "gzip, deflate",
+                "connection": "keep-alive",
+                "host": "example.com",
+                "user-agent": "testclient",
+            }
+        }
+    )
+    response = client.get(
+        "http://example.com/headers/", headers={"X-Example-Header": "example"}
+    )
+    assert (
+        response.json()
+        == {
+            "headers": {
+                "accept": "*/*",
+                "accept-encoding": "gzip, deflate",
+                "connection": "keep-alive",
+                "host": "example.com",
+                "user-agent": "testclient",
+                "x-example-header": "example",
+            }
+        }
+    )
 
-    response = client.post('http://example.com/headers/', data={'a': 1})
-    assert response.json() == {'headers': {
-        'accept': '*/*',
-        'accept-encoding': 'gzip, deflate',
-        'connection': 'keep-alive',
-        'content-length': '3',
-        'content-type': 'application/x-www-form-urlencoded',
-        'host': 'example.com',
-        'user-agent': 'testclient'
-    }}
+    response = client.post("http://example.com/headers/", data={"a": 1})
+    assert (
+        response.json()
+        == {
+            "headers": {
+                "accept": "*/*",
+                "accept-encoding": "gzip, deflate",
+                "connection": "keep-alive",
+                "content-length": "3",
+                "content-type": "application/x-www-form-urlencoded",
+                "host": "example.com",
+                "user-agent": "testclient",
+            }
+        }
+    )
 
 
 def test_accept_header(client):
-    response = client.get('/accept_header/')
-    assert response.json() == {'accept': '*/*'}
+    response = client.get("/accept_header/")
+    assert response.json() == {"accept": "*/*"}
 
 
 def test_missing_header(client):
-    response = client.get('/missing_header/')
-    assert response.json() == {'missing': None}
+    response = client.get("/missing_header/")
+    assert response.json() == {"missing": None}
 
 
 def test_path_params(client):
-    response = client.get('/path_params/abc/')
-    assert response.json() == {'params': {'example': 'abc'}}
-    response = client.get('/path_params/a%20b%20c/')
-    assert response.json() == {'params': {'example': 'a b c'}}
-    response = client.get('/path_params/abc/def/')
+    response = client.get("/path_params/abc/")
+    assert response.json() == {"params": {"example": "abc"}}
+    response = client.get("/path_params/a%20b%20c/")
+    assert response.json() == {"params": {"example": "a b c"}}
+    response = client.get("/path_params/abc/def/")
     assert response.status_code == 404
 
 
 def test_full_path_params(client):
-    response = client.get('/full_path_params/abc/def/')
-    assert response.json() == {'params': {'example': 'abc/def/'}}
+    response = client.get("/full_path_params/abc/def/")
+    assert response.json() == {"params": {"example": "abc/def/"}}
 
 
 def test_request_data(client):
-    response = client.post('/request_data/', json={'abc': 123})
-    assert response.json() == {'data': {'abc': 123}}
-    response = client.post('/request_data/')
-    assert response.json() == {'data': None}
-    response = client.post('/request_data/', data=b'...', headers={'content-type': 'unknown'})
+    response = client.post("/request_data/", json={"abc": 123})
+    assert response.json() == {"data": {"abc": 123}}
+    response = client.post("/request_data/")
+    assert response.json() == {"data": None}
+    response = client.post(
+        "/request_data/", data=b"...", headers={"content-type": "unknown"}
+    )
     assert response.status_code == 415
-    response = client.post('/request_data/', data=b'...', headers={'content-type': 'application/json'})
+    response = client.post(
+        "/request_data/", data=b"...", headers={"content-type": "application/json"}
+    )
     assert response.status_code == 400
 
 
 def test_headers_type(client):
-    h = http.Headers([('a', '123'), ('A', '456'), ('b', '789')])
-    assert 'a' in h
-    assert 'A' in h
-    assert 'b' in h
-    assert 'B' in h
-    assert 'c' not in h
-    assert h['a'] == '123'
-    assert h.get_list('a') == ['123', '456']
-    assert h.keys() == ['a', 'a', 'b']
-    assert h.values() == ['123', '456', '789']
-    assert h.items() == [('a', '123'), ('a', '456'), ('b', '789')]
-    assert list(h) == [('a', '123'), ('a', '456'), ('b', '789')]
-    assert dict(h) == {'a': '123', 'b': '789'}
+    h = http.Headers([("a", "123"), ("A", "456"), ("b", "789")])
+    assert "a" in h
+    assert "A" in h
+    assert "b" in h
+    assert "B" in h
+    assert "c" not in h
+    assert h["a"] == "123"
+    assert h.get_list("a") == ["123", "456"]
+    assert h.keys() == ["a", "a", "b"]
+    assert h.values() == ["123", "456", "789"]
+    assert h.items() == [("a", "123"), ("a", "456"), ("b", "789")]
+    assert list(h) == [("a", "123"), ("a", "456"), ("b", "789")]
+    assert dict(h) == {"a": "123", "b": "789"}
     assert repr(h) == "Headers([('a', '123'), ('a', '456'), ('b', '789')])"
-    assert http.Headers({'a': '123', 'b': '456'}) == http.Headers([('a', '123'), ('b', '456')])
-    assert http.Headers({'a': '123', 'b': '456'}) == {'B': '456', 'a': '123'}
-    assert http.Headers({'a': '123', 'b': '456'}) == [('B', '456'), ('a', '123')]
-    assert {'B': '456', 'a': '123'} == http.Headers({'a': '123', 'b': '456'})
-    assert [('B', '456'), ('a', '123')] == http.Headers({'a': '123', 'b': '456'})
+    assert (
+        http.Headers({"a": "123", "b": "456"})
+        == http.Headers([("a", "123"), ("b", "456")])
+    )
+    assert http.Headers({"a": "123", "b": "456"}) == {"B": "456", "a": "123"}
+    assert http.Headers({"a": "123", "b": "456"}) == [("B", "456"), ("a", "123")]
+    assert {"B": "456", "a": "123"} == http.Headers({"a": "123", "b": "456"})
+    assert [("B", "456"), ("a", "123")] == http.Headers({"a": "123", "b": "456"})
 
 
 def test_queryparams_type(client):
-    q = http.QueryParams([('a', '123'), ('a', '456'), ('b', '789')])
-    assert 'a' in q
-    assert 'A' not in q
-    assert 'c' not in q
-    assert q['a'] == '123'
-    assert q.get_list('a') == ['123', '456']
-    assert q.keys() == ['a', 'a', 'b']
-    assert q.values() == ['123', '456', '789']
-    assert q.items() == [('a', '123'), ('a', '456'), ('b', '789')]
-    assert list(q) == [('a', '123'), ('a', '456'), ('b', '789')]
-    assert dict(q) == {'a': '123', 'b': '789'}
+    q = http.QueryParams([("a", "123"), ("a", "456"), ("b", "789")])
+    assert "a" in q
+    assert "A" not in q
+    assert "c" not in q
+    assert q["a"] == "123"
+    assert q.get_list("a") == ["123", "456"]
+    assert q.keys() == ["a", "a", "b"]
+    assert q.values() == ["123", "456", "789"]
+    assert q.items() == [("a", "123"), ("a", "456"), ("b", "789")]
+    assert list(q) == [("a", "123"), ("a", "456"), ("b", "789")]
+    assert dict(q) == {"a": "123", "b": "789"}
     assert repr(q) == "QueryParams([('a', '123'), ('a', '456'), ('b', '789')])"
-    assert http.QueryParams({'a': '123', 'b': '456'}) == http.QueryParams([('a', '123'), ('b', '456')])
-    assert http.QueryParams({'a': '123', 'b': '456'}) == {'b': '456', 'a': '123'}
-    assert http.QueryParams({'a': '123', 'b': '456'}) == [('b', '456'), ('a', '123')]
-    assert {'b': '456', 'a': '123'} == http.QueryParams({'a': '123', 'b': '456'})
-    assert [('b', '456'), ('a', '123')] == http.QueryParams({'a': '123', 'b': '456'})
+    assert (
+        http.QueryParams({"a": "123", "b": "456"})
+        == http.QueryParams([("a", "123"), ("b", "456")])
+    )
+    assert http.QueryParams({"a": "123", "b": "456"}) == {"b": "456", "a": "123"}
+    assert http.QueryParams({"a": "123", "b": "456"}) == [("b", "456"), ("a", "123")]
+    assert {"b": "456", "a": "123"} == http.QueryParams({"a": "123", "b": "456"})
+    assert [("b", "456"), ("a", "123")] == http.QueryParams({"a": "123", "b": "456"})

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6,34 +6,34 @@ import pytest
 from apistar.codecs import JSONSchemaCodec
 
 filenames = [
-    'additionalItems.json',
-    'additionalProperties.json',
+    "additionalItems.json",
+    "additionalProperties.json",
     # 'allOf.json',
     # 'anyOf.json',
-    'default.json',
+    "default.json",
     # 'definitions.json',
     # 'dependencies.json',
     # 'enum.json',
-    'items.json',
-    'maxItems.json',
-    'maxLength.json',
-    'maxProperties.json',
-    'maximum.json',
-    'minItems.json',
-    'minLength.json',
-    'minProperties.json',
-    'minimum.json',
-    'multipleOf.json',
+    "items.json",
+    "maxItems.json",
+    "maxLength.json",
+    "maxProperties.json",
+    "maximum.json",
+    "minItems.json",
+    "minLength.json",
+    "minProperties.json",
+    "minimum.json",
+    "multipleOf.json",
     # 'not.json',
     # 'oneOf.json',
-    'pattern.json',
-    'patternProperties.json',
-    'properties.json',
+    "pattern.json",
+    "patternProperties.json",
+    "properties.json",
     # 'ref.json',
     # 'refRemote.json',
-    'required.json',
-    'type.json',
-    'uniqueItems.json'
+    "required.json",
+    "type.json",
+    "uniqueItems.json",
 ]
 
 
@@ -41,17 +41,17 @@ def load_test_cases():
     loaded = []
 
     for filename in filenames:
-        path = os.path.join('tests', 'json_schema', filename)
-        content = open(path, 'rb').read()
-        test_suite = json.loads(content.decode('utf-8'))
+        path = os.path.join("tests", "json_schema", filename)
+        content = open(path, "rb").read()
+        test_suite = json.loads(content.decode("utf-8"))
         for test_cases in test_suite:
-            description = test_cases['description']
-            schema = test_cases['schema']
-            for test in test_cases['tests']:
-                test_description = test['description']
-                test_data = test['data']
-                test_valid = test['valid']
-                full_description = '%s : %s - %s' % (
+            description = test_cases["description"]
+            schema = test_cases["schema"]
+            for test in test_cases["tests"]:
+                test_description = test["description"]
+                test_data = test["data"]
+                test_valid = test["valid"]
+                full_description = "%s : %s - %s" % (
                     filename, description, test_description
                 )
                 case = (schema, test_data, test_valid, full_description)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -7,7 +7,7 @@ class User(types.Type):
     age = validators.Integer(allow_null=True, default=None)
 
 
-def get_endpoint(name: str, age: int=None):
+def get_endpoint(name: str, age: int = None):
     raise NotImplementedError()
 
 
@@ -16,9 +16,9 @@ def post_endpoint(user: User):
 
 
 routes = [
-    Route(url='/get-endpoint/', method='GET', handler=get_endpoint),
-    Route(url='/post-endpoint/', method='POST', handler=post_endpoint),
-    Route(url='/schema/', method='GET', handler=serve_schema, documented=False),
+    Route(url="/get-endpoint/", method="GET", handler=get_endpoint),
+    Route(url="/post-endpoint/", method="POST", handler=post_endpoint),
+    Route(url="/schema/", method="GET", handler=serve_schema, documented=False),
 ]
 app = App(routes=routes)
 test_client = TestClient(app)
@@ -95,6 +95,6 @@ expected_schema = """{
 
 
 def test_get_schema():
-    response = test_client.get('/schema/')
+    response = test_client.get("/schema/")
     assert response.status_code == 200
     assert response.text == expected_schema

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -15,6 +15,7 @@ class Product(types.Type):
 
 
 class Instance():
+
     def __init__(self, **kwargs):
         for key, value in kwargs.items():
             setattr(self, key, value)
@@ -22,168 +23,157 @@ class Instance():
 
 def test_from_object():
     when = datetime.datetime(2020, 1, 1, 12, 0, 0, tzinfo=utc)
-    instance = Instance(name='abc', rating=20, created=when)
+    instance = Instance(name="abc", rating=20, created=when)
     product = Product(instance)
 
-    assert product.name == 'abc'
+    assert product.name == "abc"
     assert product.rating == 20
     assert product.created == when
-    assert dict(product) == {
-        'name': 'abc',
-        'rating': 20,
-        'created': '2020-01-01T12:00:00Z'
-    }
+    assert (
+        dict(product)
+        == {"name": "abc", "rating": 20, "created": "2020-01-01T12:00:00Z"}
+    )
 
 
 def test_from_kwargs():
     when = datetime.datetime(2020, 1, 1, 12, 0, 0, tzinfo=utc)
-    product = Product(name='abc', rating=20, created=when)
+    product = Product(name="abc", rating=20, created=when)
 
-    assert product.name == 'abc'
+    assert product.name == "abc"
     assert product.rating == 20
     assert product.created == when
-    assert dict(product) == {
-        'name': 'abc',
-        'rating': 20,
-        'created': '2020-01-01T12:00:00Z'
-    }
+    assert (
+        dict(product)
+        == {"name": "abc", "rating": 20, "created": "2020-01-01T12:00:00Z"}
+    )
 
 
 def test_from_dict():
     when = datetime.datetime(2020, 1, 1, 12, 0, 0, tzinfo=utc)
-    product = Product({'name': 'abc', 'rating': 20, 'created': when})
+    product = Product({"name": "abc", "rating": 20, "created": when})
 
-    assert product.name == 'abc'
+    assert product.name == "abc"
     assert product.rating == 20
     assert product.created == when
-    assert dict(product) == {
-        'name': 'abc',
-        'rating': 20,
-        'created': '2020-01-01T12:00:00Z'
-    }
+    assert (
+        dict(product)
+        == {"name": "abc", "rating": 20, "created": "2020-01-01T12:00:00Z"}
+    )
 
 
 def test_setattr():
     when = datetime.datetime(2020, 1, 1, 12, 0, 0, tzinfo=utc)
-    product = Product(name='abc', rating=20, created=when)
+    product = Product(name="abc", rating=20, created=when)
 
-    assert product.name == 'abc'
+    assert product.name == "abc"
     assert product.rating == 20
     assert product.created == when
-    assert dict(product) == {
-        'name': 'abc',
-        'rating': 20,
-        'created': '2020-01-01T12:00:00Z'
-    }
+    assert (
+        dict(product)
+        == {"name": "abc", "rating": 20, "created": "2020-01-01T12:00:00Z"}
+    )
 
     # Set a format field, using a native type.
     product.created = datetime.datetime(2030, 2, 2, 13, 30, 0, tzinfo=utc)
-    assert dict(product) == {
-        'name': 'abc',
-        'rating': 20,
-        'created': '2030-02-02T13:30:00Z'
-    }
+    assert (
+        dict(product)
+        == {"name": "abc", "rating": 20, "created": "2030-02-02T13:30:00Z"}
+    )
 
     # Set format field, using a string.
-    product.created = '2040-03-03T15:45:00Z'
-    assert dict(product) == {
-        'name': 'abc',
-        'rating': 20,
-        'created': '2040-03-03T15:45:00Z'
-    }
+    product.created = "2040-03-03T15:45:00Z"
+    assert (
+        dict(product)
+        == {"name": "abc", "rating": 20, "created": "2040-03-03T15:45:00Z"}
+    )
 
     # Set with an invalid value.
     with pytest.raises(exceptions.ValidationError) as exc:
         product.name = None
-    assert exc.value.detail == 'May not be null.'
+    assert exc.value.detail == "May not be null."
 
 
 def test_setitem():
     when = datetime.datetime(2020, 1, 1, 12, 0, 0, tzinfo=utc)
-    product = Product(name='abc', rating=20, created=when)
+    product = Product(name="abc", rating=20, created=when)
 
-    assert product.name == 'abc'
+    assert product.name == "abc"
     assert product.rating == 20
     assert product.created == when
-    assert dict(product) == {
-        'name': 'abc',
-        'rating': 20,
-        'created': '2020-01-01T12:00:00Z'
-    }
+    assert (
+        dict(product)
+        == {"name": "abc", "rating": 20, "created": "2020-01-01T12:00:00Z"}
+    )
 
     # Set a format field, using a native type.
-    product['created'] = datetime.datetime(2030, 2, 2, 13, 30, 0, tzinfo=utc)
-    assert dict(product) == {
-        'name': 'abc',
-        'rating': 20,
-        'created': '2030-02-02T13:30:00Z'
-    }
+    product["created"] = datetime.datetime(2030, 2, 2, 13, 30, 0, tzinfo=utc)
+    assert (
+        dict(product)
+        == {"name": "abc", "rating": 20, "created": "2030-02-02T13:30:00Z"}
+    )
 
     # Set format field, using a string.
-    product['created'] = '2040-03-03T15:45:00Z'
-    assert dict(product) == {
-        'name': 'abc',
-        'rating': 20,
-        'created': '2040-03-03T15:45:00Z'
-    }
+    product["created"] = "2040-03-03T15:45:00Z"
+    assert (
+        dict(product)
+        == {"name": "abc", "rating": 20, "created": "2040-03-03T15:45:00Z"}
+    )
 
     # Set with an invalid value.
     with pytest.raises(exceptions.ValidationError) as exc:
-        product['name'] = None
-    assert exc.value.detail == 'May not be null.'
+        product["name"] = None
+    assert exc.value.detail == "May not be null."
 
 
 def test_misc():
     when = datetime.datetime(2020, 1, 1, 12, 0, 0, tzinfo=utc)
-    instance = Instance(name='abc', rating=20, created=when)
+    instance = Instance(name="abc", rating=20, created=when)
     product = Product(instance)
 
     assert len(product) == 3
-    assert repr(product) == "<Product(name='abc', rating=20, created='2020-01-01T12:00:00Z')>"
+    assert (
+        repr(product)
+        == "<Product(name='abc', rating=20, created='2020-01-01T12:00:00Z')>"
+    )
     assert len(product._dict) == 3
-    assert list(product.keys()) == ['name', 'rating', 'created']
+    assert list(product.keys()) == ["name", "rating", "created"]
     with pytest.raises(AttributeError):
         product.other = 456
     with pytest.raises(KeyError):
-        product['other'] = 456
+        product["other"] = 456
     with pytest.raises(exceptions.ValidationError):
         Product([])
 
 
 def test_reserved_keys():
     with pytest.raises(exceptions.ConfigurationError):
+
         class Something(types.Type):
             keys = validators.String()
 
 
 def test_as_jsonschema():
     struct = encode_jsonschema(Product, to_data_structure=True)
-    assert struct == {
-        "$ref": "#/definitions/Product",
-        "definitions": {
-            "Product": {
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 10
+    assert (
+        struct
+        == {
+            "$ref": "#/definitions/Product",
+            "definitions": {
+                "Product": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string", "maxLength": 10},
+                        "rating": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 100,
+                            "default": None,
+                            "nullable": True,
+                        },
+                        "created": {"type": "string", "format": "datetime"},
                     },
-                    "rating": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "maximum": 100,
-                        "default": None,
-                        "nullable": True
-                    },
-                    "created": {
-                        "type": "string",
-                        "format": "datetime"
-                    }
-                },
-                "required": [
-                    "name",
-                    "created"
-                ]
-            }
+                    "required": ["name", "created"],
+                }
+            },
         }
-    }
+    )

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -6,43 +6,43 @@ from apistar.server.validation import ValidatedRequestData
 
 
 def str_path_param(param: str):
-    return {'param': param}
+    return {"param": param}
 
 
 def int_path_param(param: int):
-    return {'param': param}
+    return {"param": param}
 
 
 def str_query_param(param: str):
-    return {'param': param}
+    return {"param": param}
 
 
 def int_query_param(param: int):
-    return {'param': param}
+    return {"param": param}
 
 
-def str_query_param_with_default(param: str=''):
-    return {'param': param}
+def str_query_param_with_default(param: str = ""):
+    return {"param": param}
 
 
-def int_query_param_with_default(param: int=None):
-    return {'param': param}
+def int_query_param_with_default(param: int = None):
+    return {"param": param}
 
 
 def schema_enforced_str_path_param(param):
-    return {'param': param}
+    return {"param": param}
 
 
 def schema_enforced_int_path_param(param):
-    return {'param': param}
+    return {"param": param}
 
 
 def schema_enforced_str_query_param(param):
-    return {'param': param}
+    return {"param": param}
 
 
 def schema_enforced_int_query_param(param):
-    return {'param': param}
+    return {"param": param}
 
 
 class User(types.Type):
@@ -58,180 +58,217 @@ def schema_enforced_body_param(user: ValidatedRequestData):
     return {"user": user}
 
 
-document = Document([
-    # Path parameters
-    Link(url='/str_path_param/{param}/', method='GET', name='str_path_param'),
-    Link(url='/int_path_param/{param}/', method='GET', name='int_path_param'),
-    Link(
-        url='/schema_enforced_str_path_param/{param}/',
-        method='GET',
-        name='schema_enforced_str_path_param',
-        fields=[
-            Field(name='param', location='path', required=True, schema=validators.String(max_length=3))
-        ]
-    ),
-    Link(
-        url='/schema_enforced_int_path_param/{param}/',
-        method='GET',
-        name='schema_enforced_int_path_param',
-        fields=[
-            Field(name='param', location='path', required=True, schema=validators.Integer(minimum=0, maximum=1000))
-        ]
-    ),
+document = Document(
+    [
+        # Path parameters
+        Link(url="/str_path_param/{param}/", method="GET", name="str_path_param"),
+        Link(url="/int_path_param/{param}/", method="GET", name="int_path_param"),
+        Link(
+            url="/schema_enforced_str_path_param/{param}/",
+            method="GET",
+            name="schema_enforced_str_path_param",
+            fields=[
+                Field(
+                    name="param",
+                    location="path",
+                    required=True,
+                    schema=validators.String(max_length=3),
+                )
+            ],
+        ),
+        Link(
+            url="/schema_enforced_int_path_param/{param}/",
+            method="GET",
+            name="schema_enforced_int_path_param",
+            fields=[
+                Field(
+                    name="param",
+                    location="path",
+                    required=True,
+                    schema=validators.Integer(minimum=0, maximum=1000),
+                )
+            ],
+        ),
+        # Query parameters
+        Link(url="/str_query_param/", method="GET", name="str_query_param"),
+        Link(url="/int_query_param/", method="GET", name="int_query_param"),
+        Link(
+            url="/str_query_param_with_default/",
+            method="GET",
+            name="str_query_param_with_default",
+        ),
+        Link(
+            url="/int_query_param_with_default/",
+            method="GET",
+            name="int_query_param_with_default",
+        ),
+        Link(
+            url="/schema_enforced_str_query_param/",
+            method="GET",
+            name="schema_enforced_str_query_param",
+            fields=[
+                Field(
+                    name="param",
+                    location="query",
+                    schema=validators.String(max_length=3),
+                )
+            ],
+        ),
+        Link(
+            url="/schema_enforced_int_query_param/",
+            method="GET",
+            name="schema_enforced_int_query_param",
+            fields=[
+                Field(
+                    name="param",
+                    location="query",
+                    schema=validators.Integer(minimum=0, maximum=1000),
+                )
+            ],
+        ),
+        # Body parameters
+        Link(url="/type_body_param/", method="POST", handler=type_body_param),
+        Link(
+            url="/schema_enforced_body_param/",
+            method="POST",
+            name="schema_enforced_body_param",
+            encoding="application/json",
+            fields=[
+                Field(
+                    name="param",
+                    location="body",
+                    schema=validators.Object(
+                        properties={
+                            "name": validators.String(max_length=10),
+                            "age": validators.Integer(
+                                minimum=0, allow_null=True, default=None
+                            ),
+                        }
+                    ),
+                )
+            ],
+        ),
+    ]
+)
 
-    # Query parameters
-    Link(url='/str_query_param/', method='GET', name='str_query_param'),
-    Link(url='/int_query_param/', method='GET', name='int_query_param'),
-    Link(url='/str_query_param_with_default/', method='GET', name='str_query_param_with_default'),
-    Link(url='/int_query_param_with_default/', method='GET', name='int_query_param_with_default'),
-    Link(
-        url='/schema_enforced_str_query_param/',
-        method='GET',
-        name='schema_enforced_str_query_param',
-        fields=[
-            Field(name='param', location='query', schema=validators.String(max_length=3))
-        ]
-    ),
-    Link(
-        url='/schema_enforced_int_query_param/',
-        method='GET',
-        name='schema_enforced_int_query_param',
-        fields=[
-            Field(name='param', location='query', schema=validators.Integer(minimum=0, maximum=1000))
-        ]
-    ),
 
-    # Body parameters
-    Link(url='/type_body_param/', method='POST', handler=type_body_param),
-    Link(
-        url='/schema_enforced_body_param/',
-        method='POST',
-        name='schema_enforced_body_param',
-        encoding='application/json',
-        fields=[
-            Field(name='param', location='body', schema=validators.Object(properties={
-                'name': validators.String(max_length=10),
-                'age': validators.Integer(minimum=0, allow_null=True, default=None),
-            }))
-        ]
-    ),
-])
-
-
-routes = bind(document, {
-    'str_path_param': str_path_param,
-    'int_path_param': int_path_param,
-    'schema_enforced_str_path_param': schema_enforced_str_path_param,
-    'schema_enforced_int_path_param': schema_enforced_int_path_param,
-    'str_query_param': str_query_param,
-    'int_query_param': int_query_param,
-    'str_query_param_with_default': str_query_param_with_default,
-    'int_query_param_with_default': int_query_param_with_default,
-    'schema_enforced_str_query_param': schema_enforced_str_query_param,
-    'schema_enforced_int_query_param': schema_enforced_int_query_param,
-    'type_body_param': type_body_param,
-    'schema_enforced_body_param': schema_enforced_body_param
-})
+routes = bind(
+    document,
+    {
+        "str_path_param": str_path_param,
+        "int_path_param": int_path_param,
+        "schema_enforced_str_path_param": schema_enforced_str_path_param,
+        "schema_enforced_int_path_param": schema_enforced_int_path_param,
+        "str_query_param": str_query_param,
+        "int_query_param": int_query_param,
+        "str_query_param_with_default": str_query_param_with_default,
+        "int_query_param_with_default": int_query_param_with_default,
+        "schema_enforced_str_query_param": schema_enforced_str_query_param,
+        "schema_enforced_int_query_param": schema_enforced_int_query_param,
+        "type_body_param": type_body_param,
+        "schema_enforced_body_param": schema_enforced_body_param,
+    },
+)
 
 app = App(routes=routes)
 client = test.TestClient(app)
 
 
 def test_str_path_param():
-    response = client.get('/str_path_param/123/')
-    assert response.json() == {'param': '123'}
+    response = client.get("/str_path_param/123/")
+    assert response.json() == {"param": "123"}
 
 
 def test_schema_enforced_str_path_param():
-    response = client.get('/schema_enforced_str_path_param/123/')
-    assert response.json() == {'param': '123'}
+    response = client.get("/schema_enforced_str_path_param/123/")
+    assert response.json() == {"param": "123"}
 
-    response = client.get('/schema_enforced_str_path_param/1234/')
+    response = client.get("/schema_enforced_str_path_param/1234/")
     assert response.status_code == 404
-    assert response.json() == {'param': 'Must have no more than 3 characters.'}
+    assert response.json() == {"param": "Must have no more than 3 characters."}
 
 
 def test_int_path_param():
-    response = client.get('/int_path_param/123/')
-    assert response.json() == {'param': 123}
+    response = client.get("/int_path_param/123/")
+    assert response.json() == {"param": 123}
 
 
 def test_schema_enforced_int_path_param():
-    response = client.get('/schema_enforced_int_path_param/123/')
-    assert response.json() == {'param': 123}
+    response = client.get("/schema_enforced_int_path_param/123/")
+    assert response.json() == {"param": 123}
 
-    response = client.get('/schema_enforced_int_path_param/1234/')
+    response = client.get("/schema_enforced_int_path_param/1234/")
     assert response.status_code == 404
-    assert response.json() == {'param': 'Must be less than or equal to 1000.'}
+    assert response.json() == {"param": "Must be less than or equal to 1000."}
 
 
 def test_str_query_param():
-    response = client.get('/str_query_param/?param=123')
-    assert response.json() == {'param': '123'}
+    response = client.get("/str_query_param/?param=123")
+    assert response.json() == {"param": "123"}
 
-    response = client.get('/str_query_param/')
-    assert response.json() == {'param': 'This field is required.'}
+    response = client.get("/str_query_param/")
+    assert response.json() == {"param": "This field is required."}
 
 
 def test_str_query_param_with_default():
-    response = client.get('/str_query_param_with_default/?param=123')
-    assert response.json() == {'param': '123'}
+    response = client.get("/str_query_param_with_default/?param=123")
+    assert response.json() == {"param": "123"}
 
-    response = client.get('/str_query_param_with_default/')
-    assert response.json() == {'param': ''}
+    response = client.get("/str_query_param_with_default/")
+    assert response.json() == {"param": ""}
 
 
 def test_schema_enforced_str_query_param():
-    response = client.get('/schema_enforced_str_query_param/?param=123')
-    assert response.json() == {'param': '123'}
+    response = client.get("/schema_enforced_str_query_param/?param=123")
+    assert response.json() == {"param": "123"}
 
-    response = client.get('/schema_enforced_str_query_param/?param=1234')
+    response = client.get("/schema_enforced_str_query_param/?param=1234")
     assert response.status_code == 400
-    assert response.json() == {'param': 'Must have no more than 3 characters.'}
+    assert response.json() == {"param": "Must have no more than 3 characters."}
 
 
 def test_int_query_param():
-    response = client.get('/int_query_param/?param=123')
-    assert response.json() == {'param': 123}
+    response = client.get("/int_query_param/?param=123")
+    assert response.json() == {"param": 123}
 
-    response = client.get('/int_query_param/')
-    assert response.json() == {'param': 'This field is required.'}
+    response = client.get("/int_query_param/")
+    assert response.json() == {"param": "This field is required."}
 
 
 def test_int_query_param_with_default():
-    response = client.get('/int_query_param_with_default/?param=123')
-    assert response.json() == {'param': 123}
+    response = client.get("/int_query_param_with_default/?param=123")
+    assert response.json() == {"param": 123}
 
-    response = client.get('/int_query_param_with_default/')
-    assert response.json() == {'param': None}
+    response = client.get("/int_query_param_with_default/")
+    assert response.json() == {"param": None}
 
 
 def test_schema_enforced_int_query_param():
-    response = client.get('/schema_enforced_int_query_param/?param=123')
-    assert response.json() == {'param': 123}
+    response = client.get("/schema_enforced_int_query_param/?param=123")
+    assert response.json() == {"param": 123}
 
-    response = client.get('/schema_enforced_int_query_param/?param=1234')
+    response = client.get("/schema_enforced_int_query_param/?param=1234")
     assert response.status_code == 400
-    assert response.json() == {'param': 'Must be less than or equal to 1000.'}
+    assert response.json() == {"param": "Must be less than or equal to 1000."}
 
 
 def test_type_body_param():
-    response = client.post('/type_body_param/', json={'name': 'tom'})
-    assert response.json() == {'user': {'name': 'tom', 'age': None}}
+    response = client.post("/type_body_param/", json={"name": "tom"})
+    assert response.json() == {"user": {"name": "tom", "age": None}}
 
-    response = client.post('/type_body_param/', json={'name': 'x' * 100})
+    response = client.post("/type_body_param/", json={"name": "x" * 100})
     assert response.status_code == 400
-    assert response.json() == {'name': 'Must have no more than 10 characters.'}
+    assert response.json() == {"name": "Must have no more than 10 characters."}
 
-    response = client.post('/type_body_param/', json={})
+    response = client.post("/type_body_param/", json={})
     assert response.status_code == 400
-    assert response.json() == {'name': 'This field is required.'}
+    assert response.json() == {"name": "This field is required."}
 
 
 def test_schema_enforced_body_param():
-    response = client.post('/schema_enforced_body_param/', json={'name': 'tom'})
-    assert response.json() == {'user': {'name': 'tom', 'age': None}}
+    response = client.post("/schema_enforced_body_param/", json={"name": "tom"})
+    assert response.json() == {"user": {"name": "tom", "age": None}}
 
-    response = client.post('/schema_enforced_body_param/', json={'name': 'x' * 100})
+    response = client.post("/schema_enforced_body_param/", json={"name": "x" * 100})
     assert response.status_code == 400
-    assert response.json() == {'name': 'Must have no more than 10 characters.'}
+    assert response.json() == {"name": "Must have no more than 10 characters."}


### PR DESCRIPTION
This PR is to see if `black` code formatting works well for auto formatting.
This might break `isort` import order checks

```
(apistar-YBJ7r3xm) 11:22 ≡ scripts/lint                                                                                                    ᴦ/P/ apistar ≡ REFACTOR/CODE-FORMAT
+ flake8 apistar tests
+ isort apistar tests --recursive --check-only
ERROR: ~/Projects/apistar/apistar/server/app.py Imports are incorrectly sorted.
ERROR: ~/Projects/apistar/tests/test_client.py Imports are incorrectly sorted.
```