### PR TITLE
Fix _WSGIAdapter and TestClient WSGI compliance

### DIFF
--- a/apistar/test.py
+++ b/apistar/test.py
@@ -183,7 +183,8 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
 class _TestClient(requests.Session):
     def __init__(self, app: typing.Callable, scheme: str, hostname: str) -> None:
         super(_TestClient, self).__init__()
-        if app.interface == 'asgi':
+        interface = getattr(app, 'interface', None)
+        if interface == 'asgi':
             adapter = _ASGIAdapter(app)
         else:
             adapter = _WSGIAdapter(app)

--- a/apistar/test.py
+++ b/apistar/test.py
@@ -79,7 +79,7 @@ class _WSGIAdapter(requests.adapters.HTTPAdapter):
 
         def start_response(wsgi_status, wsgi_headers, exc_info=None):
             if exc_info:
-                raise exc_info[0].with_traceback(exc_info[1], exc_info[2])
+                raise exc_info[0](exc_info[1]).with_traceback(exc_info[2])
             status, _, reason = wsgi_status.partition(' ')
             raw_kwargs['status'] = int(status)
             raw_kwargs['reason'] = reason

--- a/apistar/test.py
+++ b/apistar/test.py
@@ -77,7 +77,9 @@ class _WSGIAdapter(requests.adapters.HTTPAdapter):
         """
         raw_kwargs = {}
 
-        def start_response(wsgi_status, wsgi_headers):
+        def start_response(wsgi_status, wsgi_headers, exc_info=None):
+            if exc_info:
+                raise exc_info[0].with_traceback(exc_info[1], exc_info[2])
             status, _, reason = wsgi_status.partition(' ')
             raw_kwargs['status'] = int(status)
             raw_kwargs['reason'] = reason

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -1,5 +1,4 @@
 from apistar import App, Route, TestClient, types, validators
-from apistar.server.handlers import serve_schema
 
 
 class WSGIMiddleware:
@@ -12,10 +11,6 @@ class WSGIMiddleware:
             headers.append(('Result', 'OK'))
             return start_response(status, headers, exc_info)
         return self.app(environ, custom_start_response)
-
-
-class User(types.Type):
-    name = validators.String()
 
 
 def get_endpoint():

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -1,0 +1,37 @@
+from apistar import App, Route, TestClient, types, validators
+from apistar.server.handlers import serve_schema
+
+
+class WSGIMiddleware:
+
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        def custom_start_response(status, headers, exc_info=None):
+            headers.append(('Result', 'OK'))
+            return start_response(status, headers, exc_info)
+        return self.app(environ, custom_start_response)
+
+
+class User(types.Type):
+    name = validators.String()
+
+
+def get_endpoint():
+    return None
+
+
+routes = [
+    Route(url='/get-endpoint/', method='GET', handler=get_endpoint),
+]
+app = App(routes=routes)
+
+
+def test_wsgi_middleware():
+    wrapped_app = WSGIMiddleware(app)
+    test_client = TestClient(wrapped_app)
+
+    response = test_client.get('/get-endpoint')
+    assert response.status_code == 200
+    assert response.headers['Result'] == 'OK'


### PR DESCRIPTION
The missing `exc_info=None` parameter was causing me throuble when playing with middlewares and `TestClient`. This fix shoud be straightforward. 