### PR TITLE
shutil.move in preference to os.rename

### DIFF
--- a/apistar/codecs/download.py
+++ b/apistar/codecs/download.py
@@ -1,6 +1,7 @@
 import cgi
 import os
 import posixpath
+import shutil
 import tempfile
 from urllib.parse import unquote, urlparse
 
@@ -229,7 +230,7 @@ class DownloadCodec(BaseCodec):
         # Move the temporary download file to the final location.
         if output_path != temp_path:
             output_path = _unique_output_path(output_path)
-            os.rename(temp_path, output_path)
+            shutil.move(temp_path, output_path)
 
         # Open the file and return the file object.
         output_file = open(output_path, 'rb')


### PR DESCRIPTION
Refs #447.

Use `shutil.move` in preference to `os.rename` in the download codec, [as it'll work when the tempdir and download dir are on different filesystems](https://docs.python.org/2/library/shutil.html#shutil.move).

> If the destination is on the current filesystem, then os.rename() is used. Otherwise, src is copied to dst using copy_function and then removed.

We don't yet have the client library documented, and currently only have Python, not JavaScript.
However, this fixes an issue as seen in #447 (tho in that case it's against the `coreapi` package, which we're moving away from)