### PR TITLE
Include response component.

### DIFF
--- a/apistar/server/app.py
+++ b/apistar/server/app.py
@@ -93,7 +93,8 @@ class App():
             'exc': Exception,
             'app': App,
             'path_params': PathParams,
-            'route': Route
+            'route': Route,
+            'response': Response
         }
         self.injector = Injector(components, initial_components)
 
@@ -125,14 +126,14 @@ class App():
     def serve(self, host, port, **options):
         werkzeug.run_simple(host, port, self, **options)
 
-    def render_response(self, response):
+    def render_response(self, response: Response) -> Response:
         if isinstance(response, Response):
             return response
         elif isinstance(response, str):
             return HTMLResponse(response)
         return JSONResponse(response)
 
-    def finalize_wsgi(self, response, start_response: WSGIStartResponse):
+    def finalize_wsgi(self, response: Response, start_response: WSGIStartResponse):
         start_response(
             RESPONSE_STATUS_TEXT[response.status_code],
             list(response.headers)
@@ -151,7 +152,8 @@ class App():
             'exc': None,
             'app': self,
             'path_params': None,
-            'route': None
+            'route': None,
+            'response': None,
         }
         method = environ['REQUEST_METHOD'].upper()
         path = environ['PATH_INFO']
@@ -203,7 +205,8 @@ class ASyncApp(App):
             'exc': Exception,
             'app': App,
             'path_params': PathParams,
-            'route': Route
+            'route': Route,
+            'response': Response,
         }
         self.injector = ASyncInjector(components, initial_components)
 
@@ -264,7 +267,7 @@ class ASyncApp(App):
                 await self.injector.run_async(funcs, state)
         return asgi_callable
 
-    async def finalize_asgi(self, response, send: ASGISend):
+    async def finalize_asgi(self, response: Response, send: ASGISend):
         await send({
             'type': 'http.response.start',
             'status': response.status_code,

--- a/apistar/server/app.py
+++ b/apistar/server/app.py
@@ -6,7 +6,7 @@ from apistar.server.adapters import ASGItoWSGIAdapter
 from apistar.server.asgi import (
     ASGI_COMPONENTS, ASGIReceive, ASGIScope, ASGISend
 )
-from apistar.server.components import Component
+from apistar.server.components import Component, ReturnValue
 from apistar.server.core import Route, generate_document
 from apistar.server.injector import ASyncInjector, Injector
 from apistar.server.router import Router
@@ -126,12 +126,12 @@ class App():
     def serve(self, host, port, **options):
         werkzeug.run_simple(host, port, self, **options)
 
-    def render_response(self, response: Response) -> Response:
-        if isinstance(response, Response):
-            return response
-        elif isinstance(response, str):
-            return HTMLResponse(response)
-        return JSONResponse(response)
+    def render_response(self, return_value: ReturnValue) -> Response:
+        if isinstance(return_value, Response):
+            return return_value
+        elif isinstance(return_value, str):
+            return HTMLResponse(return_value)
+        return JSONResponse(return_value)
 
     def finalize_wsgi(self, response: Response, start_response: WSGIStartResponse):
         start_response(
@@ -140,7 +140,7 @@ class App():
         )
         return [response.content]
 
-    def exception_handler(self, exc: Exception):
+    def exception_handler(self, exc: Exception) -> Response:
         if isinstance(exc, exceptions.HTTPException):
             return JSONResponse(exc.detail, exc.status_code, exc.get_headers())
         raise

--- a/apistar/server/components.py
+++ b/apistar/server/components.py
@@ -1,4 +1,5 @@
 import inspect
+import typing
 
 from apistar import exceptions
 
@@ -43,3 +44,6 @@ class Component():
 
     def resolve(self):
         raise NotImplementedError()
+
+
+ReturnValue = typing.TypeVar('ReturnValue')

--- a/apistar/server/injector.py
+++ b/apistar/server/injector.py
@@ -2,6 +2,7 @@ import asyncio
 import inspect
 
 from apistar.exceptions import ConfigurationError
+from apistar.server.components import ReturnValue
 
 
 class BaseInjector():
@@ -14,15 +15,13 @@ class Injector(BaseInjector):
 
     def __init__(self, components, initial):
         self.components = components
-        self.initial = initial
+        self.initial = dict(initial)
         self.reverse_initial = {
             val: key for key, val in initial.items()
         }
         self.resolver_cache = {}
 
     def resolve_function(self, func, output_name=None, seen_state=None, parent_parameter=None):
-        if output_name is None:
-            output_name = 'response'
         if seen_state is None:
             seen_state = set(self.initial)
 
@@ -30,8 +29,19 @@ class Injector(BaseInjector):
         kwargs = {}
         consts = {}
 
-        parameters = inspect.signature(func).parameters.values()
-        for parameter in parameters:
+        signature = inspect.signature(func)
+
+        if output_name is None:
+            if signature.return_annotation in self.reverse_initial:
+                output_name = self.reverse_initial[signature.return_annotation]
+            else:
+                output_name = 'return_value'
+
+        for parameter in signature.parameters.values():
+            if parameter.annotation is ReturnValue:
+                kwargs[parameter.name] = 'return_value'
+                continue
+
             # Check if the parameter class exists in 'initial'.
             if parameter.annotation in self.reverse_initial:
                 initial_kwarg = self.reverse_initial[parameter.annotation]
@@ -93,7 +103,7 @@ class Injector(BaseInjector):
             func_kwargs.update(consts)
             state[output_name] = func(**func_kwargs)
 
-        return state['response']
+        return state[output_name]
 
 
 class ASyncInjector(Injector):

--- a/apistar/server/injector.py
+++ b/apistar/server/injector.py
@@ -32,11 +32,6 @@ class Injector(BaseInjector):
 
         parameters = inspect.signature(func).parameters.values()
         for parameter in parameters:
-            # The 'response' keyword always indicates the previous return value.
-            if parameter.name == 'response':
-                kwargs['response'] = 'response'
-                continue
-
             # Check if the parameter class exists in 'initial'.
             if parameter.annotation in self.reverse_initial:
                 initial_kwarg = self.reverse_initial[parameter.annotation]

--- a/docs/api-guide/dependency-injection.md
+++ b/docs/api-guide/dependency-injection.md
@@ -95,6 +95,7 @@ http.Headers                   | A multidict
 http.Header                    | A single query parameter, looked up against the parameter name.
 http.Body                      | The request body, as a bytestring.
 http.Request                   | The incoming request. Includes `url`, `method`, `headers`, and `body` attributes.
+http.Response                  | The outgoing response. Only available to event hooks that run after the main handler function.
 http.PathParams                | The matched path parameters for the incoming request.
 App                            | The current application. Made available as `App` for both multithreaded and async applications.
 Route                          | The matched route for the incoming request.
@@ -104,3 +105,4 @@ server.wsgi.WSGIStartResponse  | Only for `App`.
 server.asgi.ASGIScope          | Only for `ASyncApp`.
 server.asgi.ASGIReceive        | Only for `ASyncApp`.
 server.asgi.ASGISend           | Only for `ASyncApp`.
+server.components.ReturnValue  | Used internally to access the return value of the preceeding function in a dependency injection chain.

--- a/docs/api-guide/event-hooks.md
+++ b/docs/api-guide/event-hooks.md
@@ -11,7 +11,6 @@ Here's an example...
 class CustomHeadersHook():
     def on_response(self, response: http.Response):
         response.headers['x-custom'] = 'Ran on_response()'
-        return response
 
 event_hooks = [CustomHeadersHook()]
 
@@ -20,9 +19,9 @@ app = App(routes=routes, event_hooks=event_hooks)
 
 An event hook instance may include any or all of the following methods:
 
-* `on_request(self)` - Runs before the handler function.
-* `on_response(self, response, ...)` - Runs after the handler function. Should return the response.
-* `on_error(self, response, ...)` - Runs after any exception occurs. Should return the response.
+* `on_request(self, ...)` - Runs before the handler function.
+* `on_response(self, ...)` - Runs after the handler function.
+* `on_error(self, ...)` - Runs after any exception occurs.
 
-The signature of the method may include any components that would be available
-on a handler function.
+The signature of the method may include any annotations that would be available
+on a handler function, or the `http.Response` annotation.


### PR DESCRIPTION
Makes an `http.Response` component available.

Previously this could be obtained on event hooks by a hardcoded `response` as the initial argument, but it's cleaner to present it as a general purpose component in this way.

Additionally event hooks are no longer required to return a response instance, which removes an easy tripwire (previously you'd have to both mutate the response instance, but also return it)