### PR TITLE
Add handler docstring to OpenAPI's description

### DIFF
--- a/apistar/server/core.py
+++ b/apistar/server/core.py
@@ -23,7 +23,14 @@ class Route():
         encoding = None
         if any([f.location == 'body' for f in fields]):
             encoding = 'application/json'
-        return Link(url=url, method=method, name=name, encoding=encoding, fields=fields)
+        return Link(
+            url=url,
+            method=method,
+            name=name,
+            encoding=encoding,
+            fields=fields,
+            description=handler.__doc__
+        )
 
     def generate_fields(self, url, method, handler):
         fields = []

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -8,6 +8,7 @@ class User(types.Type):
 
 
 def get_endpoint(name: str, age: int=None):
+    """endpoint description"""
     raise NotImplementedError()
 
 
@@ -34,6 +35,7 @@ expected_schema = """{
     "paths": {
         "/get-endpoint/": {
             "get": {
+                "description": "endpoint description",
                 "operationId": "get_endpoint",
                 "parameters": [
                     {


### PR DESCRIPTION
Both description and summary was missing at OpenAPI generated schema. This set the path description to the handler docstring. However I found no suitable text for summary.