### PR TITLE
Exception handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ app = App(routes=routes)
 
 
 if __name__ == '__main__':
-    app.serve('127.0.0.1', 5000, use_debugger=True, use_reloader=True)
+    app.serve('127.0.0.1', 5000, debug=True)
 ```
 
 ---

--- a/apistar/__init__.py
+++ b/apistar/__init__.py
@@ -11,7 +11,7 @@ from apistar.document import Document, Field, Link, Section
 from apistar.server import App, ASyncApp, Component, Include, Route
 from apistar.test import TestClient
 
-__version__ = '0.4.4'
+__version__ = '0.4.5'
 __all__ = [
     'App', 'ASyncApp', 'Client', 'Component', 'Document', 'Section', 'Link', 'Field',
     'Route', 'Include', 'TestClient', 'http'

--- a/apistar/http.py
+++ b/apistar/http.py
@@ -187,11 +187,13 @@ class Response:
     def __init__(self,
                  content: typing.Any,
                  status_code: int=200,
-                 headers: typing.Union[StrMapping, StrPairs]=None) -> None:
+                 headers: typing.Union[StrMapping, StrPairs]=None,
+                 exc_info=None) -> None:
         self.content = self.render(content)
         self.status_code = status_code
         self.headers = MutableHeaders(headers)
         self.set_default_headers()
+        self.exc_info = exc_info
 
     def render(self, content: typing.Any) -> bytes:
         if isinstance(content, bytes):

--- a/apistar/server/adapters.py
+++ b/apistar/server/adapters.py
@@ -10,8 +10,9 @@ class ASGItoWSGIAdapter(object):
     We want this so that we can use the Werkzeug development server and
     debugger together with an ASGI application.
     """
-    def __init__(self, asgi):
+    def __init__(self, asgi, raise_exceptions=False):
         self.asgi = asgi
+        self.raise_exceptions = raise_exceptions
         self.loop = asyncio.get_event_loop()
 
     def __call__(self, environ, start_response):
@@ -51,6 +52,7 @@ class ASGItoWSGIAdapter(object):
             'query_string': environ.get('QUERY_STRING', '').encode('latin-1'),
             'http_version': environ.get('SERVER_PROTOCOL', 'http/1.0').split('/', 1)[-1],
             'scheme': environ.get('wsgi.url_scheme', 'http'),
+            'raise_exceptions': self.raise_exceptions  # Not actually part of the ASGI spec
         }
 
         if 'REMOTE_ADDR' in environ and 'REMOTE_PORT' in environ:

--- a/apistar/test.py
+++ b/apistar/test.py
@@ -187,7 +187,8 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
 class _TestClient(requests.Session):
     def __init__(self, app: typing.Callable, scheme: str, hostname: str) -> None:
         super(_TestClient, self).__init__()
-        if app.interface == 'asgi':
+        interface = getattr(app, 'interface', None)
+        if interface == 'asgi':
             adapter = _ASGIAdapter(app)
         else:
             adapter = _WSGIAdapter(app)

--- a/docs/api-guide/applications.md
+++ b/docs/api-guide/applications.md
@@ -52,3 +52,20 @@ routes = [
 
 app = ASyncApp(routes=routes)
 ```
+
+## The development server
+
+To run the development server, you should include something like the following
+in your `app.py` module.
+
+```python
+if __name__ == '__main__':
+    app.serve('127.0.0.1', 5000, debug=True)
+```
+
+If `debug` is set to `True`, then the interactive debugger will be triggered on exceptions.
+If `debug` is not set, then exceptions will result in a 500 Server Error.
+
+You should only use `app.serve()` for local development. See the [deployment documentation][deployment] for information on running API Star in production.
+
+[deployment]: /api-guide/deployment

--- a/docs/api-guide/event-hooks.md
+++ b/docs/api-guide/event-hooks.md
@@ -20,8 +20,22 @@ app = App(routes=routes, event_hooks=event_hooks)
 An event hook instance may include any or all of the following methods:
 
 * `on_request(self, ...)` - Runs before the handler function.
-* `on_response(self, ...)` - Runs after the handler function.
-* `on_error(self, ...)` - Runs after any exception occurs.
+* `on_response(self, ...)` - Runs after the handler function, or when a handled exception occurs.
+* `on_error(self, ...)` - Runs after any unhandled exception occurs.
 
 The signature of the method may include any annotations that would be available
 on a handler function, or the `http.Response` annotation.
+
+## Error handling
+
+Subclasses of `HTTPException` are dealt with by the applications exception handler,
+and return responses, that pass through any `on_response` hooks as usual.
+
+Unhandled exceptions result in server errors, and should be treated differently.
+For these cases, any installed `on_error` event hooks will be run. This event hook
+allows you to monitor or log exceptions.
+
+It's recommend that use of `on_error` event hooks should be kept to a minimum,
+dealing only with whatever error monitoring is required. Any exceptions thrown
+in one of these handlers will result in the raw exception being raised to the
+webserver with no further error handling taking place.

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,5 +46,5 @@ app = App(routes=routes)
 
 
 if __name__ == '__main__':
-    app.serve('127.0.0.1', 5000, use_debugger=True, use_reloader=True)
+    app.serve('127.0.0.1', 5000, debug=True)
 ```

--- a/docs/topics/release-notes.md
+++ b/docs/topics/release-notes.md
@@ -2,6 +2,17 @@
 
 ## Version 0.4.x
 
+### 0.4.5
+
+* on_response now runs for both regular reponses and handled exceptions.
+* on_error now only runs for unhandled exceptions (ie. 500 reponses).
+* Return 500 responses on error.
+* Test client raises exceptions instead of returning 500 responses.
+* Add debug flag to app.serve(), to switch between debugger vs. plain responses.
+* Include `http.QueryParam` annotations in schema output, as one of the parameters.
+* Include handler docstring in schema output, as the 'description'.
+* Allow subclassing of `type.Type`.
+
 ### 0.4.4
 
 * OpenAPI schema uses `requestBody` instead of the incorrect `responseBody`.

--- a/tests/test_event_hooks.py
+++ b/tests/test_event_hooks.py
@@ -1,4 +1,4 @@
-from apistar import App, Route, exceptions, http, test
+from apistar import App, Route, http, test
 
 
 class CustomResponseHeader():
@@ -16,7 +16,7 @@ def hello_world():
 
 
 def error():
-    raise exceptions.BadRequest()
+    assert 1 == 2
 
 
 routes = [
@@ -39,5 +39,5 @@ def test_on_response():
 
 def test_on_error():
     response = client.get('/error')
-    assert response.status_code == 400
+    assert response.status_code == 500
     assert response.headers['Custom'] == 'Ran on_error'

--- a/tests/test_event_hooks.py
+++ b/tests/test_event_hooks.py
@@ -1,4 +1,8 @@
+import pytest
+
 from apistar import App, Route, http, test
+
+ON_ERROR = None
 
 
 class CustomResponseHeader():
@@ -6,9 +10,9 @@ class CustomResponseHeader():
         response.headers['Custom'] = 'Ran on_response'
         return response
 
-    def on_error(self, response: http.Response):
-        response.headers['Custom'] = 'Ran on_error'
-        return response
+    def on_error(self):
+        global ON_ERROR
+        ON_ERROR = 'Ran on_error'
 
 
 def hello_world():
@@ -38,6 +42,9 @@ def test_on_response():
 
 
 def test_on_error():
-    response = client.get('/error')
-    assert response.status_code == 500
-    assert response.headers['Custom'] == 'Ran on_error'
+    global ON_ERROR
+
+    ON_ERROR = None
+    with pytest.raises(AssertionError):
+        client.get('/error')
+    assert ON_ERROR == 'Ran on_error'


### PR DESCRIPTION
Closes #437.
Closes #443.
Closes #449.
Closes #423.
Closes #219.

* `on_response` now runs for both regular reponses and handled exceptions.
* `on_error` now only runs for unhandled exceptions (ie. 500 reponses).
* Return 500 responses on error.
* Test client raises exceptions instead of returning 500 responses.
* Add `debug` flag to `app.serve()`, to switch between debugger vs. plain responses.

