### PR TITLE
Graceful handling of cases where 'on_error' hooks raise errors

### DIFF
--- a/apistar/__init__.py
+++ b/apistar/__init__.py
@@ -11,7 +11,7 @@ from apistar.document import Document, Field, Link, Section
 from apistar.server import App, ASyncApp, Component, Include, Route
 from apistar.test import TestClient
 
-__version__ = '0.5.1'
+__version__ = '0.5.2'
 __all__ = [
     'App', 'ASyncApp', 'Client', 'Component', 'Document', 'Section', 'Link', 'Field',
     'Route', 'Include', 'TestClient', 'http'

--- a/apistar/server/adapters.py
+++ b/apistar/server/adapters.py
@@ -41,7 +41,7 @@ class ASGItoWSGIAdapter(object):
 
         try:
             self.loop.run_until_complete(asgi_coroutine(recieve, send))
-        except:
+        except Exception:
             if self.raise_exceptions:
                 raise
 

--- a/docs/topics/release-notes.md
+++ b/docs/topics/release-notes.md
@@ -2,6 +2,10 @@
 
 ## Version 0.5.x
 
+### 0.5.2
+
+* Graceful handling of cases where `on_error` handling raises errors.
+
 ### 0.5.1
 
 * Fix for handlers than annotate `Response`, not being available to the `ReturnValue` annotation when `render_response` is called.


### PR DESCRIPTION
Closes #463

`on_error` hooks are now run separately to the final error handler. We ensure that we always return a 500 response even when an `on_error` hook itself raises an error. In those cases the innermost exception ends up being used as `exc_info`.