### PR TITLE
Instantiate event hooks on each request/response

### DIFF
--- a/apistar/__init__.py
+++ b/apistar/__init__.py
@@ -11,7 +11,7 @@ from apistar.document import Document, Field, Link, Section
 from apistar.server import App, ASyncApp, Component, Include, Route
 from apistar.test import TestClient
 
-__version__ = '0.5.3'
+__version__ = '0.5.4'
 __all__ = [
     'App', 'ASyncApp', 'Client', 'Component', 'Document', 'Section', 'Link', 'Field',
     'Route', 'Include', 'TestClient', 'http'

--- a/apistar/server/app.py
+++ b/apistar/server/app.py
@@ -110,7 +110,7 @@ class App():
             if hasattr(hook, 'on_request')
         ]
 
-        self.on_response_functions = [self.render_response] + [
+        self.on_response_functions = [
             hook.on_response for hook in reversed(event_hooks)
             if hasattr(hook, 'on_response')
         ] + [self.finalize_wsgi]
@@ -187,7 +187,7 @@ class App():
             else:
                 funcs = (
                     self.on_request_functions +
-                    [route.handler] +
+                    [route.handler, self.render_response] +
                     self.on_response_functions
                 )
             return self.injector.run(funcs, state)
@@ -293,7 +293,7 @@ class ASyncApp(App):
                 else:
                     funcs = (
                         self.on_request_functions +
-                        [route.handler] +
+                        [route.handler, self.render_response] +
                         self.on_response_functions
                     )
                 await self.injector.run_async(funcs, state)

--- a/apistar/server/app.py
+++ b/apistar/server/app.py
@@ -40,8 +40,8 @@ class App():
             msg = 'components must be a list of instances of Component.'
             assert all([isinstance(component, Component) for component in components]), msg
         if event_hooks:
-            msg = 'event_hooks must be a list of instances, not classes.'
-            assert not any([isinstance(event_hook, type) for event_hook in event_hooks]), msg
+            msg = 'event_hooks must be a list.'
+            assert isinstance(event_hooks, (list, tuple)), msg
 
         routes = routes + self.include_extra_routes(schema_url, static_url)
         self.init_document(routes)
@@ -49,8 +49,11 @@ class App():
         self.init_templates(template_dir)
         self.init_staticfiles(static_url, static_dir)
         self.init_injector(components)
-        self.init_hooks(event_hooks)
         self.debug = False
+        self.event_hooks = event_hooks
+
+        # Ensure event hooks can all be instantiated.
+        self.get_event_hooks()
 
     def include_extra_routes(self, schema_url=None, static_url=None):
         extra_routes = []
@@ -101,29 +104,32 @@ class App():
         }
         self.injector = Injector(components, initial_components)
 
-    def init_hooks(self, event_hooks=None):
-        if event_hooks is None:
-            event_hooks = []
+    def get_event_hooks(self):
+        event_hooks = []
+        for hook in self.event_hooks or []:
+            if isinstance(hook, type):
+                # New style usage, instantiate hooks on requests.
+                event_hooks.append(hook())
+            else:
+                # Old style usage, to be deprecated on the next version bump.
+                event_hooks.append(hook)
 
-        self.on_request_functions = [
+        on_request = [
             hook.on_request for hook in event_hooks
             if hasattr(hook, 'on_request')
         ]
 
-        self.on_response_functions = [
+        on_response = [
             hook.on_response for hook in reversed(event_hooks)
             if hasattr(hook, 'on_response')
-        ] + [self.finalize_wsgi]
+        ]
 
-        self.on_exception_functions = [self.exception_handler] + [
-            hook.on_response for hook in reversed(event_hooks)
-            if hasattr(hook, 'on_response')
-        ] + [self.finalize_wsgi]
-
-        self.on_error_functions = [
+        on_error = [
             hook.on_error for hook in reversed(event_hooks)
             if hasattr(hook, 'on_error')
         ]
+
+        return on_request, on_response, on_error
 
     def reverse_url(self, name: str, **params):
         return self.router.reverse_url(name, **params)
@@ -178,6 +184,12 @@ class App():
         }
         method = environ['REQUEST_METHOD'].upper()
         path = environ['PATH_INFO']
+
+        if self.event_hooks is None:
+            on_request, on_response, on_error = [], [], []
+        else:
+            on_request, on_response, on_error = self.get_event_hooks()
+
         try:
             route, path_params = self.router.lookup(path, method)
             state['route'] = route
@@ -186,22 +198,25 @@ class App():
                 funcs = [route.handler]
             else:
                 funcs = (
-                    self.on_request_functions +
+                    on_request +
                     [route.handler, self.render_response] +
-                    self.on_response_functions
+                    on_response +
+                    [self.finalize_wsgi]
                 )
             return self.injector.run(funcs, state)
         except Exception as exc:
             try:
                 state['exc'] = exc
-                funcs = self.on_exception_functions
+                funcs = (
+                    [self.exception_handler] +
+                    on_response +
+                    [self.finalize_wsgi]
+                )
                 return self.injector.run(funcs, state)
             except Exception as inner_exc:
                 try:
                     state['exc'] = inner_exc
-                    funcs = self.on_error_functions
-                    if funcs:
-                        self.injector.run(funcs, state)
+                    self.injector.run(on_error, state)
                 finally:
                     funcs = [self.error_handler, self.finalize_wsgi]
                     return self.injector.run(funcs, state)
@@ -241,30 +256,6 @@ class ASyncApp(App):
         }
         self.injector = ASyncInjector(components, initial_components)
 
-    def init_hooks(self, event_hooks=None):
-        if event_hooks is None:
-            event_hooks = []
-
-        self.on_request_functions = [
-            hook.on_request for hook in event_hooks
-            if hasattr(hook, 'on_request')
-        ]
-
-        self.on_response_functions = [self.render_response] + [
-            hook.on_response for hook in reversed(event_hooks)
-            if hasattr(hook, 'on_response')
-        ] + [self.finalize_asgi]
-
-        self.on_exception_functions = [self.exception_handler] + [
-            hook.on_response for hook in reversed(event_hooks)
-            if hasattr(hook, 'on_response')
-        ] + [self.finalize_asgi]
-
-        self.on_error_functions = [
-            hook.on_error for hook in reversed(event_hooks)
-            if hasattr(hook, 'on_error')
-        ]
-
     def init_staticfiles(self, static_url: str, static_dir: str=None):
         if not static_dir:
             self.statics = None
@@ -284,6 +275,12 @@ class ASyncApp(App):
             }
             method = scope['method']
             path = scope['path']
+
+            if self.event_hooks is None:
+                on_request, on_response, on_error = [], [], []
+            else:
+                on_request, on_response, on_error = self.get_event_hooks()
+
             try:
                 route, path_params = self.router.lookup(path, method)
                 state['route'] = route
@@ -292,22 +289,25 @@ class ASyncApp(App):
                     funcs = [route.handler]
                 else:
                     funcs = (
-                        self.on_request_functions +
+                        on_request +
                         [route.handler, self.render_response] +
-                        self.on_response_functions
+                        on_response +
+                        [self.finalize_asgi]
                     )
                 await self.injector.run_async(funcs, state)
             except Exception as exc:
                 try:
                     state['exc'] = exc
-                    funcs = self.on_exception_functions
+                    funcs = (
+                        [self.exception_handler] +
+                        on_response +
+                        [self.finalize_asgi]
+                    )
                     await self.injector.run_async(funcs, state)
                 except Exception as inner_exc:
                     try:
                         state['exc'] = inner_exc
-                        funcs = self.on_error_functions
-                        if funcs:
-                            await self.injector.run(funcs, state)
+                        await self.injector.run(on_error, state)
                     finally:
                         funcs = [self.error_handler, self.finalize_asgi]
                         await self.injector.run(funcs, state)

--- a/apistar/server/injector.py
+++ b/apistar/server/injector.py
@@ -95,6 +95,8 @@ class Injector(BaseInjector):
         try:
             steps = self.resolver_cache[funcs]
         except KeyError:
+            if not funcs:
+                return
             steps = self.resolve_functions(funcs)
             self.resolver_cache[funcs] = steps
 
@@ -116,6 +118,8 @@ class ASyncInjector(Injector):
         try:
             steps = self.resolver_cache[funcs]
         except KeyError:
+            if not funcs:
+                return
             steps = self.resolve_functions(funcs)
             self.resolver_cache[funcs] = steps
 

--- a/docs/topics/release-notes.md
+++ b/docs/topics/release-notes.md
@@ -2,6 +2,10 @@
 
 ## Version 0.5.x
 
+### 0.5.4
+
+* Event hooks instantiated on each request/response cycle.
+
 ### 0.5.3
 
 * Support multipart and urlencoded content in `RequestData`.

--- a/tests/test_event_hooks.py
+++ b/tests/test_event_hooks.py
@@ -6,9 +6,11 @@ ON_ERROR = None
 
 
 class CustomResponseHeader():
+    def on_request(self):
+        self.message = 'Ran hooks'
+
     def on_response(self, response: http.Response):
-        response.headers['Custom'] = 'Ran on_response'
-        return response
+        response.headers['Custom'] = self.message
 
     def on_error(self):
         global ON_ERROR
@@ -28,7 +30,7 @@ routes = [
     Route('/error', method='GET', handler=error),
 ]
 
-event_hooks = [CustomResponseHeader()]
+event_hooks = [CustomResponseHeader]
 
 app = App(routes=routes, event_hooks=event_hooks)
 
@@ -38,7 +40,7 @@ client = test.TestClient(app)
 def test_on_response():
     response = client.get('/hello')
     assert response.status_code == 200
-    assert response.headers['Custom'] == 'Ran on_response'
+    assert response.headers['Custom'] == 'Ran hooks'
 
 
 def test_on_error():


### PR DESCRIPTION
Allows state to be stored on event hooks between the request and response.

Event hooks should now be passed as classes, but this is currently backwards compatible and still allows the old-style usage.