### PR TITLE
Fix coercion when issubclass receive an instance

### DIFF
--- a/apistar/server/core.py
+++ b/apistar/server/core.py
@@ -92,6 +92,7 @@ class Route():
 
     def coerce_generics(self, annotation):
         if (
+            isinstance(annotation, type) and
             issubclass(annotation, typing.List) and
             annotation.__args__ and
             issubclass(annotation.__args__[0], types.Type)


### PR DESCRIPTION
Schema responses wasn't being generated or was failing with the following examples.
 
```python

def handler() -> Number:
    # fails because of logic 
    pass

def handler() -> Number():
    # fails because issubclass receive an instance
    pass
```