### PR TITLE
Add support for multiple query parameter with same name

### DIFF
--- a/apistar/server/core.py
+++ b/apistar/server/core.py
@@ -49,7 +49,10 @@ class Route():
                 field = Field(name=name, location='path', schema=schema)
                 fields.append(field)
 
-            elif param.annotation in (param.empty, int, float, bool, str, http.QueryParam):
+            elif param.annotation in (param.empty, int, float, bool, str,
+                                      typing.List[int], typing.List[float],
+                                      typing.List[bool], typing.List[str],
+                                      http.QueryParam):
                 if param.default is param.empty:
                     kwargs = {}
                 elif param.default is None:
@@ -62,6 +65,10 @@ class Route():
                     float: validators.Number(**kwargs),
                     bool: validators.Boolean(**kwargs),
                     str: validators.String(**kwargs),
+                    typing.List[str]: validators.Array(validators.String(), **kwargs),
+                    typing.List[int]: validators.Array(validators.Integer(), **kwargs),
+                    typing.List[float]: validators.Array(validators.Number(), **kwargs),
+                    typing.List[bool]: validators.Array(validators.Boolean(), **kwargs),
                     http.QueryParam: validators.String(**kwargs),
                 }[param.annotation]
                 field = Field(name=name, location='query', schema=schema)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,3 +1,5 @@
+import typing
+
 from apistar import Route, test, types, validators
 from apistar.server.app import App
 
@@ -34,6 +36,38 @@ def bool_query_param_with_default(param: bool=False):
     return {'param': param}
 
 
+def str_list_query_param(param: typing.List[str]):
+    return {'param': param}
+
+
+def str_list_query_param_with_default(param: typing.List[str]=[]):
+    return {'param': param}
+
+
+def int_list_query_param(param: typing.List[int]):
+    return {'param': param}
+
+
+def int_list_query_param_with_default(param: typing.List[int]=[]):
+    return {'param': param}
+
+
+def bool_list_query_param(param: typing.List[bool]):
+    return {'param': param}
+
+
+def bool_list_query_param_with_default(param: typing.List[bool]=[]):
+    return {'param': param}
+
+
+def float_list_query_param(param: typing.List[float]):
+    return {'param': param}
+
+
+def float_list_query_param_with_default(param: typing.List[float]=[]):
+    return {'param': param}
+
+
 class User(types.Type):
     name = validators.String(max_length=10)
     age = validators.Integer(minimum=0, allow_null=True, default=None)
@@ -55,6 +89,16 @@ routes = [
     Route(url='/str_query_param_with_default/', method='GET', handler=str_query_param_with_default),
     Route(url='/int_query_param_with_default/', method='GET', handler=int_query_param_with_default),
     Route(url='/bool_query_param_with_default/', method='GET', handler=bool_query_param_with_default),
+
+    # Query parameters with List[]
+    Route(url='/str_list_query_param/', method='GET', handler=str_list_query_param),
+    Route(url='/str_list_query_param_with_default/', method='GET', handler=str_list_query_param_with_default),
+    Route(url='/int_list_query_param/', method='GET', handler=int_list_query_param),
+    Route(url='/int_list_query_param_with_default/', method='GET', handler=int_list_query_param_with_default),
+    Route(url='/bool_list_query_param/', method='GET', handler=bool_list_query_param),
+    Route(url='/bool_list_query_param_with_default/', method='GET', handler=bool_list_query_param_with_default),
+    Route(url='/float_list_query_param/', method='GET', handler=float_list_query_param),
+    Route(url='/float_list_query_param_with_default/', method='GET', handler=float_list_query_param_with_default),
 
     # Body parameters
     Route(url='/type_body_param/', method='POST', handler=type_body_param),
@@ -126,6 +170,100 @@ def test_bool_query_param_with_default():
 
     response = client.get('/bool_query_param_with_default/')
     assert response.json() == {'param': False}
+
+
+def test_str_list_query_param():
+    response = client.get('/str_list_query_param/?param=a&param=b')
+    assert response.json() == {'param': ['a', 'b']}
+
+    response = client.get('/str_list_query_param/?param=a')
+    assert response.json() == {'param': ['a']}
+
+    response = client.get('/str_query_param/')
+    assert response.json() == {'param': 'This field is required.'}
+
+
+def test_str_list_query_param_with_default():
+    response = client.get('/str_list_query_param_with_default/?param=a&param=b')
+    assert response.json() == {'param': ['a', 'b']}
+
+    response = client.get('/str_list_query_param/?param=a')
+    assert response.json() == {'param': ['a']}
+
+    response = client.get('/str_list_query_param_with_default/')
+    assert response.json() == {'param': []}
+
+
+def test_int_list_query_param():
+    response = client.get('/int_list_query_param/?param=4&param=2')
+    assert response.json() == {'param': [4, 2]}
+
+    response = client.get('/int_list_query_param/?param=4')
+    assert response.json() == {'param': [4]}
+
+    response = client.get('/int_query_param/')
+    assert response.json() == {'param': 'This field is required.'}
+
+
+def test_int_list_query_param_with_default():
+    response = client.get('/int_list_query_param_with_default/?param=4&param=2')
+    assert response.json() == {'param': [4, 2]}
+
+    response = client.get('/int_list_query_param/?param=4')
+    assert response.json() == {'param': [4]}
+
+    response = client.get('/int_list_query_param_with_default/')
+    assert response.json() == {'param': []}
+
+
+def test_bool_list_query_param():
+    response = client.get('/bool_list_query_param/?param=True&param=False')
+    assert response.json() == {'param': [True, False]}
+
+    response = client.get('/bool_list_query_param/?param=True')
+    assert response.json() == {'param': [True]}
+
+    response = client.get('/bool_list_query_param/?param=False')
+    assert response.json() == {'param': [False]}
+
+    response = client.get('/bool_query_param/')
+    assert response.json() == {'param': 'This field is required.'}
+
+
+def test_bool_list_query_param_with_default():
+    response = client.get('/bool_list_query_param_with_default/?param=True&param=False')
+    assert response.json() == {'param': [True, False]}
+
+    response = client.get('/bool_list_query_param/?param=True')
+    assert response.json() == {'param': [True]}
+
+    response = client.get('/bool_list_query_param/?param=False')
+    assert response.json() == {'param': [False]}
+
+    response = client.get('/bool_list_query_param_with_default/')
+    assert response.json() == {'param': []}
+
+
+def test_float_list_query_param():
+    response = client.get('/float_list_query_param/?param=3.14&param=3.15')
+    assert response.json() == {'param': [3.14, 3.15]}
+
+    response = client.get('/float_list_query_param/?param=3.14')
+    assert response.json() == {'param': [3.14]}
+
+    response = client.get('/float_list_query_param/')
+    assert response.json() == {'param': 'This field is required.'}
+
+
+def test_float_list_query_param_with_default():
+    response = client.get('/float_list_query_param_with_default/?param=3.14&param=3.15')
+    assert response.json() == {'param': [3.14, 3.15]}
+
+    response = client.get('/float_list_query_param/?param=3.14')
+    assert response.json() == {'param': [3.14]}
+
+    response = client.get('/float_list_query_param_with_default/')
+    assert response.json() == {'param': []}
 
 
 def test_type_body_param():


### PR DESCRIPTION
With this PR, apistar will support multiple query parameter with same name like this:

```python
# /welcome/?name=Bob&name=Alice&name=Eve
def welcome(name: typing.List[str]=None):
    if name is None:
        return {'message': 'Welcome to API Star!'}
    return {'message': 'Welcome to API Star, %s!' % ', '.join(name)}