### PR TITLE
exc_info is an optional positional argument in start_response for wsgi

### DIFF
--- a/apistar/server/app.py
+++ b/apistar/server/app.py
@@ -168,7 +168,7 @@ class App():
         start_response(
             RESPONSE_STATUS_TEXT[response.status_code],
             list(response.headers),
-            exc_info=response.exc_info
+            response.exc_info
         )
         return [response.content]
 


### PR DESCRIPTION
#504