### PR TITLE
Docs fails in ASyncApp because is not named 'static'

### DIFF
--- a/apistar/server/app.py
+++ b/apistar/server/app.py
@@ -256,7 +256,10 @@ class ASyncApp(App):
         if static_url:
             static_url = static_url.rstrip('/') + '/{+filename}'
             extra_routes += [
-                Route(static_url, method='GET', handler=serve_static_asgi, documented=False, standalone=True)
+                Route(
+                    static_url, method='GET', handler=serve_static_asgi,
+                    name='static', documented=False, standalone=True
+                )
             ]
         return extra_routes
 


### PR DESCRIPTION
NoReverseMatch is raised when query `/docs/` because the docs view isn't named **static** as its sync counterpart.

```python
apistar.exceptions.NoReverseMatch: Could not build url for endpoint 'static' with values ['filename']. Did you mean 'serve_static_asgi' instead?
```