### PR TITLE
Fix static files not loading due to 500 server error #1

### DIFF
--- a/apistar/server/app.py
+++ b/apistar/server/app.py
@@ -276,7 +276,7 @@ class ASyncApp(App):
         self.injector = ASyncInjector(components, initial_components)
 
     def init_staticfiles(self, static_url: str, static_dir: str=None, packages: typing.Sequence[str]=None):
-        if not static_dir:
+        if not static_dir and not packages:
             self.statics = None
         else:
             self.statics = ASyncStaticFiles(static_url, static_dir, packages)


### PR DESCRIPTION
Add missing check for packages before short-circuiting AsyncApp.init_staticfiles().

fixes #531