### PR TITLE
Fix links to h3 coredocs-link-title in docs

### DIFF
--- a/apistar/templates/docs/layout/link.html
+++ b/apistar/templates/docs/layout/link.html
@@ -9,7 +9,7 @@
         <i class="fa fa-exchange"></i> Interact
     </button>-->
 
-    <h3 id="{{ section_key }}-{{ link_key }}" class="coredocs-link-title">{{ link.title|default(link.name, True) }} <a href="#{{ section_key }}-{{ link_key }}"><i class="fa fa-link" aria-hidden="true"></i>
+    <h3 id="{{ section.name }}-{{ link.name }}" class="coredocs-link-title">{{ link.title|default(link.name, True) }} <a href="#{{ section.name }}-{{ link.name }}"><i class="fa fa-link" aria-hidden="true"></i>
 </a></h3>
 
     <div class="meta">


### PR DESCRIPTION
The side-bar links to endpoints didn't work, since the anchors for the endpoints where broken.