### PR TITLE
Remove parenthesis from CustomHeadersHook example

### DIFF
--- a/docs/api-guide/event-hooks.md
+++ b/docs/api-guide/event-hooks.md
@@ -8,7 +8,7 @@ a group of functions to be run in response to particular events.
 Here's an example...
 
 ```python
-class CustomHeadersHook():
+class CustomHeadersHook:
     def on_response(self, response: http.Response):
         response.headers['x-custom'] = 'Ran on_response()'
 


### PR DESCRIPTION
No need for the `()` on the class definition.