### PR TITLE
Fix docs endpoint for async applications

### DIFF
--- a/apistar/server/app.py
+++ b/apistar/server/app.py
@@ -285,7 +285,7 @@ class ASyncApp(App):
         self.injector = ASyncInjector(components, initial_components)
 
     def init_staticfiles(self, static_url: str, static_dir: str=None, packages: typing.Sequence[str]=None):
-        if not static_dir:
+        if not static_dir and not packages:
             self.statics = None
         else:
             self.statics = ASyncStaticFiles(static_url, static_dir, packages)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,17 @@
+from apistar import App, ASyncApp, TestClient
+
+async_app = ASyncApp(routes=[])
+async_test_client = TestClient(async_app)
+
+app = App(routes=[])
+test_client = TestClient(app)
+
+
+def test_docs():
+    response = test_client.get('/docs/')
+    assert response.status_code == 200
+
+
+def test_docs_async():
+    response = async_test_client.get('/docs/')
+    assert response.status_code == 200


### PR DESCRIPTION
The main issue was that static asset routes were not correctly added for async applications, in case the application did not have static assets themselves. 

Also, include a very simplistic test to make sure docs endpoint works.