### PR TITLE
allow schema generation for validators.Any type (#552)

### DIFF
--- a/apistar/codecs/jsonschema.py
+++ b/apistar/codecs/jsonschema.py
@@ -301,4 +301,7 @@ class JSONSchemaCodec(BaseCodec):
                 value['uniqueItems'] = item.unique_items
             return value
 
+        elif isinstance(item, validators.Any):
+            return value
+
         raise Exception('Cannot encode item %s' % item)


### PR DESCRIPTION
Don't bail out when an Any type is encountered.

According to my reading of the spec, `{}` is the type that represents Any. See the Quickstart section on http://json-schema.org/ and https://cswr.github.io/JsonSchema/spec/multiple_types/