### PR TITLE
Adding custom extra codecs

### DIFF
--- a/apistar/server/app.py
+++ b/apistar/server/app.py
@@ -16,9 +16,7 @@ from apistar.server.injector import ASyncInjector, Injector
 from apistar.server.router import Router
 from apistar.server.staticfiles import ASyncStaticFiles, StaticFiles
 from apistar.server.templates import Templates
-from apistar.server.validation import (
-    VALIDATION_COMPONENTS, RequestDataComponent
-)
+from apistar.server.validation import VALIDATION_COMPONENTS, CodecsComponent
 from apistar.server.wsgi import (
     RESPONSE_STATUS_TEXT, WSGI_COMPONENTS, WSGIEnviron, WSGIStartResponse
 )
@@ -59,7 +57,7 @@ class App():
             assert all([isinstance(codec, BaseCodec) for codec in codecs]), msg
 
         routes = routes + self.include_extra_routes(schema_url, docs_url, static_url)
-        self.include_extra_codecs(codecs)
+        components = self.include_component_codecs(components, codecs)
         self.init_document(routes)
         self.init_router(routes)
         self.init_templates(template_dir, packages)
@@ -94,10 +92,13 @@ class App():
             ]
         return extra_routes
 
-    def include_extra_codecs(self, codecs=None):
+    def include_component_codecs(self, components, codecs=None):
         # Override component with more codecs
-        global VALIDATION_COMPONENTS
-        VALIDATION_COMPONENTS = (RequestDataComponent(extra_codecs=codecs),) + VALIDATION_COMPONENTS
+        codec_component = CodecsComponent(codecs)
+        if not components:
+            components = []
+        components.append(codec_component)
+        return components
 
     def init_document(self, routes):
         self.document = generate_document(routes)

--- a/apistar/server/app.py
+++ b/apistar/server/app.py
@@ -16,7 +16,9 @@ from apistar.server.injector import ASyncInjector, Injector
 from apistar.server.router import Router
 from apistar.server.staticfiles import ASyncStaticFiles, StaticFiles
 from apistar.server.templates import Templates
-from apistar.server.validation import VALIDATION_COMPONENTS, RequestDataComponent
+from apistar.server.validation import (
+    VALIDATION_COMPONENTS, RequestDataComponent
+)
 from apistar.server.wsgi import (
     RESPONSE_STATUS_TEXT, WSGI_COMPONENTS, WSGIEnviron, WSGIStartResponse
 )

--- a/apistar/server/validation.py
+++ b/apistar/server/validation.py
@@ -13,19 +13,19 @@ Codecs = typing.NewType('Codecs', list)
 
 
 class CodecsComponent(Component):
-    default_codecs = [
+    default_codecs = (
         codecs.JSONCodec(),
         codecs.URLEncodedCodec(),
         codecs.MultiPartCodec(),
-    ]
+    )
 
     def can_handle_parameter(self, parameter: inspect.Parameter):
         return parameter.annotation is Codecs
 
     def __init__(self, codecs=None):
         if codecs is None:
-            codecs = []
-        self.codecs = codecs + self.default_codecs
+            codecs = ()
+        self.codecs = tuple(codecs) + self.default_codecs
 
     def resolve(self) -> Codecs:
         return Codecs(self.codecs)

--- a/apistar/server/validation.py
+++ b/apistar/server/validation.py
@@ -17,6 +17,7 @@ class RequestDataComponent(Component):
         codecs.URLEncodedCodec(),
         codecs.MultiPartCodec(),
     ]
+
     def __init__(self, extra_codecs=None):
         self.codecs = (
             extra_codecs + self.base_codecs

--- a/apistar/server/validation.py
+++ b/apistar/server/validation.py
@@ -12,12 +12,17 @@ ValidatedRequestData = typing.TypeVar('ValidatedRequestData')
 
 
 class RequestDataComponent(Component):
-    def __init__(self):
-        self.codecs = [
-            codecs.JSONCodec(),
-            codecs.URLEncodedCodec(),
-            codecs.MultiPartCodec(),
-        ]
+    base_codecs = [
+        codecs.JSONCodec(),
+        codecs.URLEncodedCodec(),
+        codecs.MultiPartCodec(),
+    ]
+    def __init__(self, extra_codecs=None):
+        self.codecs = (
+            extra_codecs + self.base_codecs
+            if extra_codecs is not None and len(extra_codecs)
+            else self.base_codecs
+        )
 
     def can_handle_parameter(self, parameter: inspect.Parameter):
         return parameter.annotation is http.RequestData
@@ -29,7 +34,6 @@ class RequestDataComponent(Component):
             return None
 
         content_type = headers.get('Content-Type')
-
         try:
             codec = negotiate_content_type(self.codecs, content_type)
         except exceptions.NoCodecAvailable:
@@ -149,7 +153,6 @@ class CompositeParamComponent(Component):
 
 
 VALIDATION_COMPONENTS = (
-    RequestDataComponent(),
     ValidatePathParamsComponent(),
     ValidateQueryParamsComponent(),
     ValidateRequestDataComponent(),

--- a/scripts/test
+++ b/scripts/test
@@ -7,4 +7,4 @@ fi
 
 set -x
 
-PYTHONPATH=. ${PREFIX}pytest -s --ignore venv --ignore apistar/layouts --cov=apistar --cov=tests --cov-report=term-missing ${@}
+PYTHONPATH=. ${PREFIX}pytest --ignore venv --ignore apistar/layouts --cov=apistar --cov=tests --cov-report=term-missing ${@}

--- a/scripts/test
+++ b/scripts/test
@@ -7,4 +7,4 @@ fi
 
 set -x
 
-PYTHONPATH=. ${PREFIX}pytest --ignore venv --ignore apistar/layouts --cov=apistar --cov=tests --cov-report=term-missing ${@}
+PYTHONPATH=. ${PREFIX}pytest -s --ignore venv --ignore apistar/layouts --cov=apistar --cov=tests --cov-report=term-missing ${@}

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -2,13 +2,12 @@
 #
 # Test extra codecs
 #
-import json
-
 import collections
+import json
 
 import pytest
 
-from apistar import Route, http, ASyncApp, App, test
+from apistar import App, ASyncApp, Route, http, test
 from apistar.codecs import BaseCodec
 from apistar.exceptions import ParseError
 
@@ -47,7 +46,7 @@ def post_overriden_json(data: http.RequestData):
 
 
 def post_disorder(data: http.RequestData):
-    return data.decode('UTF-8')
+    return data.decode("UTF-8")
 
 
 routes = [
@@ -67,13 +66,11 @@ def client(request):
 
 def test_overriden_json_codec(client):
     response = client.post("/overriden", json={"Do": "Belong"})
-    assert {'Do': 'Belong', 'Not': 'Belonging'}  == response.json()
+    assert {"Do": "Belong", "Not": "Belonging"} == response.json()
 
 
 def test_dumb_codec(client):
     response = client.post(
-        '/disordered',
-        data="doidhf",
-        headers={"Content-Type": "text/plain"}
+        "/disordered", data="doidhf", headers={"Content-Type": "text/plain"}
     )
-    assert response.content == b'ddfhio'
+    assert response.content == b"ddfhio"


### PR DESCRIPTION
With this PR custom codecs can override current media types (like a different Json serializer) or extend the media-types supported (for instance introduce messagepack).