### PR TITLE
Make json.dumps default function raise, not return, TypeError

### DIFF
--- a/apistar/http.py
+++ b/apistar/http.py
@@ -242,4 +242,4 @@ class JSONResponse(Response):
         if isinstance(obj, types.Type):
             return dict(obj)
         error = "Object of type '%s' is not JSON serializable."
-        return TypeError(error % type(obj).__name__)
+        raise TypeError(error % type(obj).__name__)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -102,6 +102,12 @@ def return_response(data: http.RequestData) -> http.Response:
     return http.JSONResponse({'example': 'content'})
 
 
+def return_unserializable_json() -> dict:
+    class Dummy:
+        pass
+    return {'dummy': Dummy()}
+
+
 routes = [
     Route('/request/', 'GET', get_request),
     Route('/method/', 'GET', get_method),
@@ -126,6 +132,7 @@ routes = [
     Route('/return_string/', 'GET', return_string),
     Route('/return_data/', 'GET', return_data),
     Route('/return_response/', 'GET', return_response),
+    Route('/return_unserializable_json/', 'GET', return_unserializable_json),
 ]
 
 
@@ -363,6 +370,12 @@ def test_return_data(client):
 def test_return_response(client):
     response = client.get('/return_response/')
     assert response.json() == {'example': 'content'}
+
+
+def test_return_unserializable_json(client):
+    with pytest.raises(TypeError) as excinfo:
+        client.get('/return_unserializable_json/')
+    assert str(excinfo).endswith("Object of type 'Dummy' is not JSON serializable.")
 
 
 def test_headers_type(client):


### PR DESCRIPTION
After returning a dict of data from a route, I ran into `RecursionError: maximum recursion depth exceeded in comparison` from `abc.py` and it took me a long time to figure out why: I was returning a `datetime.datetime` as part of the data, which is not JSON serializable by default.

Turns out, because the `default` method used for JSON serialization *returns* a TypeError instead of raising it, the `default` method gets called with a TypeError over and over again, recursively, eventually hiding the original exception entirely.

I don't know if there was any reason to return the TypeError instead of raising it, but it's clearly not working as intended.

The `return` has been present since https://github.com/encode/apistar/pull/400.