### PR TITLE
fix link doc template (#537)

### DIFF
--- a/apistar/templates/docs/layout/link.html
+++ b/apistar/templates/docs/layout/link.html
@@ -58,7 +58,7 @@
         <tbody>
             {% if expanded %}
                 {% for key, schema in expanded.items() %}
-                    <tr><td class="parameter-name"><code>{{ key }}</code>{% if key in expanded.required %} <span class="label label-warning">required</span>{% endif %}</td><td>{% if schema.description %}{{ schema.description }}{% endif %}</td></tr>
+                    <tr><td class="parameter-name"><code>{{ key }}</code>{% if key in field.schema.required %} <span class="label label-warning">required</span>{% endif %}</td><td>{% if schema.description %}{{ schema.description }}{% endif %}</td></tr>
                 {% endfor %}
             {% else %}
             <tr><td class="parameter-name"><code>{{ field.name }}</code>{% if field.required %} <span class="label label-warning">required</span>{% endif %}</td><td>{% if field.description or field.schema.description %}{{ field.description or field.schema.description }}{% endif %}</td></tr>


### PR DESCRIPTION
Fix doc template so that required parameters are shown correctly as such for Request Body fields. See issue #537.