### PR TITLE
Fix resource leak on ASyncStaticFiles

### DIFF
--- a/apistar/server/staticfiles.py
+++ b/apistar/server/staticfiles.py
@@ -89,19 +89,23 @@ class ASGIFileSession():
                 'body': b''
             })
         else:
-            chunk = await file.read(8192)
-            more_body = True
+            try:
+                chunk = await file.read(8192)
+                more_body = True
 
-            while more_body:
-                next_chunk = await file.read(8192)
-                more_body = bool(next_chunk)
+                while more_body:
+                    next_chunk = await file.read(8192)
+                    more_body = bool(next_chunk)
 
-                await send({
-                    'type': 'http.response.body',
-                    'body': chunk,
-                    'more_body': more_body
-                })
-                chunk = next_chunk
+                    await send({
+                        'type': 'http.response.body',
+                        'body': chunk,
+                        'more_body': more_body
+                    })
+                    chunk = next_chunk
+            finally:
+                # Free resource
+                await file.close()
 
     async def get_response(self, method, request_headers):
         if method != 'GET' and method != 'HEAD':


### PR DESCRIPTION
Leak occurs when printing docs, but it would likely arise when using `ASyncStaticFiles` generally, just run async server with `PYTHONASYNCIODEBUG=1` and warnings will start to show up.

Warning:

```python 
/usr/local/lib/python3.6/asyncio/coroutines.py:110: ResourceWarning: unclosed file
        <_io.BufferedReader 
          name='/usr/local/lib/python3.6/site-packages/apistar/static/fonts/fontawesome-webfont.woff'>
       return self.gen.send(None)
```