### PR TITLE
Documentation: Fix python code tab switcher

### DIFF
--- a/apistar/templates/docs/index.html
+++ b/apistar/templates/docs/index.html
@@ -35,5 +35,26 @@
 
         <script src="{{ static_url('apistar/js/jquery-1.10.2.min.js') }}"></script>
         <script src="{{ static_url('apistar/js/bootstrap.min.js') }}"></script>
+        <script language="JavaScript">
+            // Language Control
+            $(document).ready(function () {
+                $('#language-control li').click(function (event) {
+                    event.preventDefault();
+                    var $languageMenuItem = $(this).find('a');
+                    var $languageControls = $(this).closest('ul').find('li');
+                    var $languageControlLinks = $languageControls.find('a');
+                    var language = $languageMenuItem.data('language');
+
+                    $languageControlLinks.not('[data-language="' + language + '"]').removeClass('active');
+                    $languageControlLinks.filter('[data-language="' + language + '"]').addClass('active');
+
+                    $('#selected-language').text(language);
+
+                    var $codeBlocks = $('pre.highlight');
+                    $codeBlocks.not('[data-language="' + language + '"]').addClass('d-none')
+                    $codeBlocks.filter('[data-language="' + language + '"]').removeClass('d-none')
+                });
+            });
+        </script>
     </body>
 </html>

--- a/apistar/templates/docs/layout/content.html
+++ b/apistar/templates/docs/layout/content.html
@@ -14,7 +14,6 @@
                     {% endfor %}
                 </ul>
             {% endif %}
-        </ul>
     </div>
 </div>
 <div class="row intro">


### PR DESCRIPTION
Hi,

it looks that since [b99d4ac](https://github.com/encode/apistar/commit/b99d4ac0c737e7590ca00826305c5b91075dcb3c) and [a8ce4e0](https://github.com/encode/apistar/commit/a8ce4e0c0059dff6db02caab0ef4abf0de2b70cb) nobody is calling the necessary code for the language chooser tabs that was removed when removing _old_ `api.js` file:

```javascript
//////////// api.js:66 /////////////
$(function () {
  var $selectedAuthentication = $('#selected-authentication')
  var $authControl = $('#auth-control')
  var $authTokenModal = $('#auth_token_modal')
  var $authBasicModal = $('#auth_basic_modal')
  var $authSessionModal = $('#auth_session_modal')

 ////// ----> REMOVED code for `language-control` navs
  // Language Control
  $('#language-control li').click(function (event) {
    event.preventDefault()
    var $languageMenuItem = $(this).find('a')
    var $languageControls = $(this).closest('ul').find('li')
    var $languageControlLinks = $languageControls.find('a')
    var language = $languageMenuItem.data('language')

    $languageControlLinks.not('[data-language="' + language + '"]').removeClass('active')
    $languageControlLinks.filter('[data-language="' + language + '"]').addClass('active')

    $('#selected-language').text(language)

    var $codeBlocks = $('pre.highlight')
    $codeBlocks.not('[data-language="' + language + '"]').addClass('d-none')
    $codeBlocks.filter('[data-language="' + language + '"]').removeClass('d-none')
  })
////// <----- REMOVED code for `language-control` navs
```

So somewhat the language picker is now only showing up Javascript, **Python samples were dead forever** 😅 

This PR adds _only_ the code necessary in the `index.html` file embedded, if for any case you do not want an small piece of JS in the `body`, it can easily be _restored_ into an `api.js` and just point to it. For now it's so small the code that is not very verbose.

