### PR TITLE
Fix the enum assert into the NumericType.__init__ method.

### DIFF
--- a/apistar/validators.py
+++ b/apistar/validators.py
@@ -194,7 +194,7 @@ class NumericType(Validator):
         assert isinstance(exclusive_minimum, bool)
         assert isinstance(exclusive_maximum, bool)
         assert multiple_of is None or isinstance(multiple_of, (int, float))
-        assert enum is None or isinstance(enum, list) and all([isinstance(i, str) for i in enum])
+        assert enum is None or isinstance(enum, list) and all([isinstance(i, self.numeric_type) for i in enum])
         assert format is None or isinstance(format, str)
 
         self.minimum = minimum

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,25 @@
+import pytest
+from apistar import validators
+from apistar import exceptions
+
+
+def test_number_validator_enum_positive():
+    v = validators.Number(enum=[0.1])
+    assert v.validate(0.1) == 0.1
+
+
+def test_number_validator_enum_negative():
+    v = validators.Number(enum=[0.1])
+    with pytest.raises(exceptions.ValidationError):
+        v.validate(0.2)
+
+
+def test_integer_validator_enum_positive():
+    v = validators.Integer(enum=[0])
+    assert v.validate(0) == 0
+
+
+def test_integer_validator_enum_negative():
+    v = validators.Integer(enum=[0])
+    with pytest.raises(exceptions.ValidationError):
+        v.validate(1)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,6 +1,6 @@
 import pytest
-from apistar import validators
-from apistar import exceptions
+
+from apistar import exceptions, validators
 
 
 def test_number_validator_enum_positive():


### PR DESCRIPTION
Now the NumericType has an invalid assert for the enum argument.