### PR TITLE
python 3.7 issubclass() fix

### DIFF
--- a/apistar/types.py
+++ b/apistar/types.py
@@ -50,6 +50,12 @@ class TypeMetaclass(ABCMeta):
         validators.Validator._creation_counter += 1
         return super(TypeMetaclass, cls).__new__(cls, name, bases, attrs)
 
+    def __subclasscheck__(cls, subclass):
+        try:
+            return ABCMeta.__subclasscheck__(cls, subclass)
+        except TypeError:
+            return False
+
 
 class Type(Mapping, metaclass=TypeMetaclass):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Hi!

I recently ran to an error trying to start my new project using python 3.7 and apistar!
It appeared that this happened due to a new behavior of ABCMeta.__subclasscheck__ and I ask you to merge this small PR, fixing issue #595 

Regards,
Alexander