### PR TITLE
Whitenoise options on App instantiation

### DIFF
--- a/apistar/server/app.py
+++ b/apistar/server/app.py
@@ -33,7 +33,8 @@ class App():
                  docs_url='/docs/',
                  static_url='/static/',
                  components=None,
-                 event_hooks=None):
+                 event_hooks=None,
+                 whitenoise_opts=None):
 
         packages = tuple() if packages is None else tuple(packages)
 
@@ -55,7 +56,7 @@ class App():
         self.init_document(routes)
         self.init_router(routes)
         self.init_templates(template_dir, packages)
-        self.init_staticfiles(static_url, static_dir, packages)
+        self.init_staticfiles(static_url, static_dir, packages, whitenoise_opts)
         self.init_injector(components)
         self.debug = False
         self.event_hooks = event_hooks
@@ -102,11 +103,15 @@ class App():
             }
             self.templates = Templates(template_dir, packages, template_globals)
 
-    def init_staticfiles(self, static_url: str, static_dir: str=None, packages: typing.Sequence[str]=None):
+    def init_staticfiles(self, static_url: str, static_dir: str=None, packages: typing.Sequence[str]=None,
+                         whitenoise_opts: typing.Mapping[typing.AnyStr, typing.Any]=None):
         if not static_dir and not packages:
             self.statics = None
         else:
-            self.statics = StaticFiles(static_url, static_dir, packages)
+            if whitenoise_opts is None:
+                whitenoise_opts = {}
+
+            self.statics = StaticFiles(static_url, static_dir, packages, **whitenoise_opts)
 
     def init_injector(self, components=None):
         components = components if components else []
@@ -284,11 +289,15 @@ class ASyncApp(App):
         }
         self.injector = ASyncInjector(components, initial_components)
 
-    def init_staticfiles(self, static_url: str, static_dir: str=None, packages: typing.Sequence[str]=None):
+    def init_staticfiles(self, static_url: str, static_dir: str=None, packages: typing.Sequence[str]=None,
+                         whitenoise_opts: typing.Mapping[typing.AnyStr, typing.Any]=None):
         if not static_dir and not packages:
             self.statics = None
         else:
-            self.statics = ASyncStaticFiles(static_url, static_dir, packages)
+            if whitenoise_opts is None:
+                whitenoise_opts = {}
+
+            self.statics = ASyncStaticFiles(static_url, static_dir, packages, **whitenoise_opts)
 
     def __call__(self, scope):
         async def asgi_callable(receive, send):

--- a/apistar/server/staticfiles.py
+++ b/apistar/server/staticfiles.py
@@ -17,9 +17,9 @@ class StaticFiles(BaseStaticFiles):
     Static file handling for WSGI applications, using `whitenoise`.
     """
 
-    def __init__(self, prefix: str, static_dir: str=None, packages: typing.Sequence[str]=None):
+    def __init__(self, prefix: str, static_dir: str=None, packages: typing.Sequence[str]=None, **kwargs):
         self.check_requirements()
-        self.whitenoise = whitenoise.WhiteNoise(application=self.not_found)
+        self.whitenoise = whitenoise.WhiteNoise(application=self.not_found, **kwargs)
         if static_dir is not None:
             self.whitenoise.add_files(static_dir, prefix=prefix)
         for package in packages or []:

--- a/docs/api-guide/static-files.md
+++ b/docs/api-guide/static-files.md
@@ -6,6 +6,8 @@ If you're using `ASyncApp` you'll also need to install `aiofiles`.
 To include static files in your application, create a directory to contain the static files,
 and include it with the `static_dir` argument when instantiating the app.
 
+It's possible to configure `whitenoise` passing options through `whitenoise_opts` parameter.
+
 ```python
 import os
 
@@ -14,7 +16,7 @@ STATIC_DIR = os.path.join(BASE_DIR, 'static')
 
 ...
 
-app = App(routes=routes, static_dir=STATIC_DIR)
+app = App(routes=routes, static_dir=STATIC_DIR, whitenoise_opts={"autorefresh": True})
 ```
 
 The default behavior is to serve static files from the URL prefix `/static/`.


### PR DESCRIPTION
Allow apistar `App` and `ASyncApp` to configure Whitenoise instance. That is specially useful to use `autorefresh` feature of whitenoise while running in debug mode.