### PR TITLE
Add tox to test multiple Python 3 versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .coverage
 .git
 .mypy_cache
+.pytest_cache
+.tox
 __pycache__
 /*.egg-info
 /htmlcov

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = py{35,36,37},flake8
+
+[testenv]
+passenv = LANG
+deps=-rrequirements.txt
+commands=
+    {toxinidir}/scripts/test
+
+[testenv:flake8]
+deps=-rrequirements.txt
+commands=
+    {toxinidir}/scripts/lint


### PR DESCRIPTION
I was poking around and noticed that the tests are failing on Python 3.7. Seems it is only a 3.7 thing, but I can't see an obvious fix. I added a tox file to easily test against multiple versions - it might be useful.

I'll try and find some time to poke around more and see if I can come up with a fix.