### PR TITLE
python37 type check fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - "pypy3.5"
     - "3.5"
     - "3.6"
+    - "3.7-dev"
 
 install:
     - pip install -r requirements.txt

--- a/apistar/server/core.py
+++ b/apistar/server/core.py
@@ -88,9 +88,10 @@ class Route():
         return Response(encoding='application/json', status_code=200, schema=annotation)
 
     def coerce_generics(self, annotation):
+        origin = getattr(annotation, '__origin__', annotation)
         if (
-            isinstance(annotation, type) and
-            issubclass(annotation, typing.List) and
+            isinstance(origin, type) and
+            issubclass(origin, typing.List) and
             getattr(annotation, '__args__', None) and
             issubclass(annotation.__args__[0], types.Type)
         ):


### PR DESCRIPTION
This pull request is a finishing of #598 ( python 3.7 issue - #595 )
It fixes type checks which prevented to generate schema responses when running in python 3.7
It also adds `3.7-dev` to the travis matrix.

I ran tests on python 3.6 and 3.7 and they're ok:
========================== 316 passed in 8.79 seconds ==========================.......
