### PR TITLE
Load components from cache when calling error hooks

### DIFF
--- a/apistar/server/injector.py
+++ b/apistar/server/injector.py
@@ -82,9 +82,9 @@ class Injector(BaseInjector):
         steps.append(step)
         return steps
 
-    def resolve_functions(self, funcs):
+    def resolve_functions(self, funcs, state):
         steps = []
-        seen_state = set(self.initial)
+        seen_state = set(self.initial) | set(state)
         for func in funcs:
             func_steps = self.resolve_function(func, seen_state=seen_state, set_return=True)
             steps.extend(func_steps)
@@ -97,7 +97,7 @@ class Injector(BaseInjector):
         except KeyError:
             if not funcs:
                 return
-            steps = self.resolve_functions(funcs)
+            steps = self.resolve_functions(funcs, state)
             self.resolver_cache[funcs] = steps
 
         for func, is_async, kwargs, consts, output_name, set_return in steps:
@@ -120,7 +120,7 @@ class ASyncInjector(Injector):
         except KeyError:
             if not funcs:
                 return
-            steps = self.resolve_functions(funcs)
+            steps = self.resolve_functions(funcs, state)
             self.resolver_cache[funcs] = steps
 
         for func, is_async, kwargs, consts, output_name, set_return in steps:


### PR DESCRIPTION
This fixes an issue where `on_error` hooks don't have access to the same component instances as other hooks and handlers. In addition, this may fix other resolution issues/heisenbugs but I was mainly concerned with fixing `on_error` as any code right now that tries to clean up resources on error (eg. db connections) based on a component instance is probably incorrect.