### PR TITLE
Fixed typo in apistar.yml path property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Let's also create a configuration file `apistar.yml`:
 
 ```yaml
 schema:
-  path: schema.yaml
+  path: schema.yml
   format: openapi
 ```
 


### PR DESCRIPTION
Schema.yaml should be schema.yml to match the first file created.