### PR TITLE
Set minimum Python version to 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@
 <a href="https://pypi.python.org/pypi/apistar">
     <img src="https://badge.fury.io/py/apistar.svg" alt="Package version">
 </a>
+<a href="https://pypi.python.org/pypi/apistar">
+    <img src="https://img.shields.io/pypi/pyversions/apistar.svg" alt="Python versions">
+</a>
 </p>
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,9 @@
 <a href="https://pypi.python.org/pypi/apistar">
     <img src="https://badge.fury.io/py/apistar.svg" alt="Package version">
 </a>
+<a href="https://pypi.python.org/pypi/apistar">
+    <img src="https://img.shields.io/pypi/pyversions/apistar.svg" alt="Python versions">
+</a>
 </p>
 
 ---

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
     packages=get_packages("apistar"),
     package_data=get_package_data("apistar"),
     install_requires=["click", "jinja2", "requests", "pyyaml", "typesystem"],
+    python_requires=">=3.6",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Environment :: Web Environment",
@@ -79,8 +80,8 @@ setup(
         "Topic :: Internet :: WWW/HTTP",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Programming Language :: Python :: Implementation :: CPython",
     ],


### PR DESCRIPTION
Adds a shiny ![badge](https://img.shields.io/pypi/pyversions/apistar.svg) that will get updated to the right Python versions once a new release is made.

Closes #654 and closes #645