### PR TITLE
Allow 'examples' field in "Parameter", "MediaType" and "Components"

### DIFF
--- a/apistar/document.py
+++ b/apistar/document.py
@@ -186,6 +186,7 @@ class Field:
         required: bool = None,
         schema: typing.Any = None,
         example: typing.Any = None,
+        examples: typing.Any = None,
     ):
         assert location in ("path", "query", "body", "cookie", "header", "formData")
         if required is None:
@@ -200,6 +201,7 @@ class Field:
         self.required = required
         self.schema = schema
         self.example = example
+        self.examples = examples
 
 
 class Response:

--- a/apistar/schemas/openapi.py
+++ b/apistar/schemas/openapi.py
@@ -2,6 +2,7 @@ import re
 from urllib.parse import urljoin
 
 import typesystem
+
 from apistar.document import Document, Field, Link, Section
 from apistar.schemas.jsonschema import JSON_SCHEMA
 
@@ -40,6 +41,17 @@ OPEN_API = typesystem.Object(
     pattern_properties={"^x-": typesystem.Any()},
     additional_properties=False,
     required=["openapi", "info", "paths"],
+)
+
+EXAMPLES = typesystem.Object(
+    pattern_properties={
+        "^[a-zA-Z0-9\-]+$": typesystem.Object(
+            properties={"value": typesystem.Any(), "summary": typesystem.Text()},
+            additional_properties=False,
+            required=["value"],
+        )
+    },
+    additional_properties=False,
 )
 
 definitions["Info"] = typesystem.Object(
@@ -182,6 +194,7 @@ definitions["Parameter"] = typesystem.Object(
         "style": typesystem.Choice(choices=["matrix", "label", "form", "simple", "spaceDelimited", "pipeDelimited", "deepObject"]),
         "schema": JSON_SCHEMA | SCHEMA_REF,
         "example": typesystem.Any(),
+        "examples": EXAMPLES,
         # TODO: Other fields
     },
     pattern_properties={"^x-": typesystem.Any()},
@@ -242,7 +255,8 @@ definitions["MediaType"] = typesystem.Object(
     properties={
         "schema": JSON_SCHEMA | SCHEMA_REF,
         "example": typesystem.Any(),
-        # TODO 'examples', 'encoding'
+        "examples": EXAMPLES,
+        # TODO 'encoding'
     },
     pattern_properties={"^x-": typesystem.Any()},
     additional_properties=False,
@@ -286,6 +300,7 @@ definitions["Components"] = typesystem.Object(
                 "SecurityScheme", definitions=definitions
             )
         ),
+        "examples": EXAMPLES,
         # TODO: Other fields
     },
     pattern_properties={"^x-": typesystem.Any()},

--- a/apistar/schemas/openapi.py
+++ b/apistar/schemas/openapi.py
@@ -454,9 +454,10 @@ class OpenAPI:
         ]
 
         # TODO: Handle media type generically here...
-        body_schema = lookup(
-            operation_info, ["requestBody", "content", "application/json", "schema"]
+        body_definition = lookup(
+            operation_info, ["requestBody", "content", "application/json"], {}
         )
+        body_schema = body_definition.get("schema")
 
         encoding = None
         if body_schema:
@@ -473,7 +474,13 @@ class OpenAPI:
             field_name = lookup(
                 operation_info, ["requestBody", "x-name"], default=field_name
             )
-            fields += [Field(name=field_name, location="body", schema=schema)]
+            fields += [
+                Field(
+                    name=field_name, location="body", schema=schema,
+                    example=body_definition.get("example"),
+                    examples=body_definition.get("examples")
+                )
+            ]
 
         return Link(
             name=name,

--- a/apistar/schemas/openapi.py
+++ b/apistar/schemas/openapi.py
@@ -495,6 +495,7 @@ class OpenAPI:
         required = parameter.get("required", False)
         schema = parameter.get("schema")
         example = parameter.get("example")
+        examples = parameter.get("examples")
 
         if schema is not None:
             if "$ref" in schema:
@@ -512,4 +513,5 @@ class OpenAPI:
             required=required,
             schema=schema,
             example=example,
+            examples=examples
         )

--- a/apistar/themes/apistar/templates/layout/examples.html
+++ b/apistar/themes/apistar/templates/layout/examples.html
@@ -1,20 +1,18 @@
-{% for field in fields %}
-    {% if field.examples %}
-        <h4>Examples</h4>
-        <p>parameter: <code>{{ field.name }}</code>
-        <table class="parameters table table-bordered table-striped">
-            <thead>
-                <tr><th>Name</th><th>Value</th><th>Summary</th></tr>
-            </thead>
-            <tbody>
-                {% for name, example in field.examples.items() %}
-                    <tr>
-                        <td>{{ name }}</td>
-                        <td ><code>{{ example.value|pprint }}</code></td>
-                        <td>{% if example.summary %}{{ example.summary }}{% endif %}</td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    {% endif %}
-{% endfor %}
+{% if examples %}
+    <h4>Examples</h4>
+    <p>parameter: <code>{{ field.name }}</code>
+    <table class="parameters table table-bordered table-striped">
+        <thead>
+            <tr><th>Name</th><th>Value</th><th>Summary</th></tr>
+        </thead>
+        <tbody>
+            {% for name, example in examples.items() %}
+                <tr>
+                    <td>{{ name }}</td>
+                    <td ><code>{{ example.value|pprint }}</code></td>
+                    <td>{% if example.summary %}{{ example.summary }}{% endif %}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% endif %}

--- a/apistar/themes/apistar/templates/layout/examples.html
+++ b/apistar/themes/apistar/templates/layout/examples.html
@@ -1,0 +1,20 @@
+{% for field in fields %}
+    {% if field.examples %}
+        <h4>Examples</h4>
+        <p>parameter: <code>{{ field.name }}</code>
+        <table class="parameters table table-bordered table-striped">
+            <thead>
+                <tr><th>Name</th><th>Value</th><th>Summary</th></tr>
+            </thead>
+            <tbody>
+                {% for name, example in field.examples.items() %}
+                    <tr>
+                        <td>{{ name }}</td>
+                        <td ><code>{{ example.value|pprint }}</code></td>
+                        <td>{% if example.summary %}{{ example.summary }}{% endif %}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+{% endfor %}

--- a/apistar/themes/apistar/templates/layout/link.html
+++ b/apistar/themes/apistar/templates/layout/link.html
@@ -24,7 +24,11 @@
                 {% endfor %}
             </tbody>
         </table>
-        {% include 'apistar/layout/examples.html' %}
+        {% for field in fields %}
+            {% with examples=field.examples %}
+                {% include 'apistar/layout/examples.html' %}
+            {% endwith %}
+        {% endfor %}
     {% endwith %}
 {% endif %}
 {% if link.get_query_fields() %}
@@ -41,7 +45,11 @@
                 {% endfor %}
             </tbody>
         </table>
-        {% include 'apistar/layout/examples.html' %}
+        {% for field in fields %}
+            {% with examples=field.examples %}
+                {% include 'apistar/layout/examples.html' %}
+            {% endwith %}
+        {% endfor %}
     {% endwith %}
 {% endif %}
 {% if link.get_body_field() %}
@@ -63,6 +71,9 @@
             {% endif %}
         </tbody>
     </table>
+    {% with examples=field.examples %}
+        {% include 'apistar/layout/examples.html' %}
+    {% endwith %}
 {% endif %}
     </div>
 

--- a/apistar/themes/apistar/templates/layout/link.html
+++ b/apistar/themes/apistar/templates/layout/link.html
@@ -11,32 +11,38 @@
         {% if link.description %}<p class="description">{{ link.description }}</p>{% endif %}
 
 {% if link.get_path_fields() %}
-    <h4>Path Parameters</h4>
-    <p>The following parameters should be included in the URL path.</p>
-    <table class="parameters table table-bordered table-striped">
-        <thead>
-            <tr><th>Parameter</th><th>Description</th></tr>
-        </thead>
-        <tbody>
-            {% for field in link.get_path_fields() %}
-            <tr><td class="parameter-name"><code>{{ field.name }}</code>{% if field.required %} <span class="label label-warning">required</span>{% endif %}</td><td>{% if field.description or field.schema.description %}{{ field.description or field.schema.description }}{% endif %}</td></tr>
-            {% endfor %}
-        </tbody>
-    </table>
+    {% with fields=link.get_path_fields() %}
+        <h4>Path Parameters</h4>
+        <p>The following parameters should be included in the URL path.</p>
+        <table class="parameters table table-bordered table-striped">
+            <thead>
+                <tr><th>Parameter</th><th>Description</th></tr>
+            </thead>
+            <tbody>
+                {% for field in fields %}
+                <tr><td class="parameter-name"><code>{{ field.name }}</code>{% if field.required %} <span class="label label-warning">required</span>{% endif %}</td><td>{% if field.description or field.schema.description %}{{ field.description or field.schema.description }}{% endif %}{% if field.example %}<p>Example: <code>{{ field.example }}</code></p>{% endif %}</td></tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% include 'apistar/layout/examples.html' %}
+    {% endwith %}
 {% endif %}
 {% if link.get_query_fields() %}
-    <h4>Query Parameters</h4>
-    <p>The following parameters should be included as part of a URL query string.</p>
-    <table class="parameters table table-bordered table-striped">
-        <thead>
-            <tr><th>Parameter</th><th>Description</th></tr>
-        </thead>
-        <tbody>
-            {% for field in link.get_query_fields() %}
-            <tr><td class="parameter-name"><code>{{ field.name }}</code>{% if field.required %} <span class="label label-warning">required</span>{% endif %}</td><td>{% if field.description or field.schema.description %}{{ field.description or field.schema.description }}{% endif %}</td></tr>
-            {% endfor %}
-        </tbody>
-    </table>
+    {% with fields=link.get_query_fields() %}
+        <h4>Query Parameters</h4>
+        <p>The following parameters should be included as part of a URL query string.</p>
+        <table class="parameters table table-bordered table-striped">
+            <thead>
+                <tr><th>Parameter</th><th>Description</th></tr>
+            </thead>
+            <tbody>
+                {% for field in fields %}
+                <tr><td class="parameter-name"><code>{{ field.name }}</code>{% if field.required %} <span class="label label-warning">required</span>{% endif %}</td><td>{% if field.description or field.schema.description %}{{ field.description or field.schema.description }}{% endif %}{% if field.example %}<p>Example: <code>{{ field.example }}</code></p>{% endif %}</td></tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% include 'apistar/layout/examples.html' %}
+    {% endwith %}
 {% endif %}
 {% if link.get_body_field() %}
     {% set field=link.get_body_field() %}
@@ -58,7 +64,6 @@
         </tbody>
     </table>
 {% endif %}
-
     </div>
 
     <div class="col-md-6 section-secondary">

--- a/testcases/openapi/petstore-with-examples.yaml
+++ b/testcases/openapi/petstore-with-examples.yaml
@@ -1,0 +1,137 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+          examples:
+            min:
+              value: 0
+              # summary field is optional
+            max:
+              value: 100
+              summary: a maximum value of 100
+      responses:
+        '200':
+          description: An paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+              examples:
+                cats:
+                  summary: a list of cats
+                  value:
+                    [{
+                      "id": 0,
+                      "name": "felix",
+                      "tags": "cat"
+                    }]
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+          example: 10
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+  examples:
+    cats:
+      summary: a list of cats
+      value:
+        [{
+          "id": 0,
+          "name": "felix",
+          "tags": "cat"
+        }]
+
+

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -10,6 +10,7 @@ filenames = [
     # 'testcases/openapi/link-example.yaml',
     "testcases/openapi/petstore-expanded.yaml",
     "testcases/openapi/petstore.yaml",
+    "testcases/openapi/petstore-with-examples.yaml",
     "testcases/openapi/uspto.yaml",
 ]
 


### PR DESCRIPTION
This pull requests will add the following:
- Extend the openapi validator  to allow the `examples` field, see https://swagger.io/docs/specification/adding-examples/ and https://swagger.io/specification/#componentsObject
- Render the examples (and the already existing example field) in the `apistar` theme documentation.

<img width="1149" alt="apistar-examples" src="https://user-images.githubusercontent.com/121401/65146776-e9534a00-da1c-11e9-9117-8faf95edbdf0.png">


