### PR TITLE
Added tox and python 3.8 on tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,6 @@
+[run]
+branch = True
+
 [report]
 exclude_lines =
     # Have to re-enable the standard pragma

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .git
 .mypy_cache
 .pytest_cache
+.tox
 __pycache__
 /*.egg-info
 /htmlcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ python:
     - "3.6"
     - "3.7"
     - "3.8"
-    - "pypy3"
 
 install:
     - pip install -U -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,14 @@ cache: pip
 python:
     - "3.6"
     - "3.7"
+    - "3.8"
+    - "pypy3"
 
 install:
     - pip install -U -r requirements.txt
 
 script:
-    - scripts/lint
-    - scripts/test
+    - scripts/ci
 
 after_script:
     - codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ isort
 pytest
 pytest-cov
 starlette
+tox

--- a/scripts/tox
+++ b/scripts/tox
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+tox -r -p all

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Programming Language :: Python :: Implementation :: CPython",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38},pypy3.6
+envlist = py{36,37,38}
 
 [testenv]
 deps = -rrequirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py{36,37,38},pypy3.6
+
+[testenv]
+deps = -rrequirements.txt
+whitelist_externals = sh
+commands =
+    sh scripts/ci


### PR DESCRIPTION
Included:
- tox.ini added on root directory to test apistar with python 3.6, 3.7 and 3.8
- [branch](https://en.wikipedia.org/wiki/Code_coverage#Basic_coverage_criteria) included on test report