### PR TITLE
Attempt two different encodings for request body

### DIFF
--- a/apistar/schemas/openapi.py
+++ b/apistar/schemas/openapi.py
@@ -439,13 +439,17 @@ class OpenAPI:
         ]
 
         # TODO: Handle media type generically here...
-        body_schema = lookup(
-            operation_info, ["requestBody", "content", "application/json", "schema"]
-        )
-
         encoding = None
+        supported_body_encodings = ["application/json", "multipart/form-data"]
+        for body_encoding in supported_body_encodings:
+            body_schema = lookup(
+                operation_info, ["requestBody", "content", body_encoding, "schema"]
+            )
+            if body_schema:
+                encoding = body_encoding
+                break
+
         if body_schema:
-            encoding = "application/json"
             if "$ref" in body_schema:
                 ref = body_schema["$ref"]
                 schema = schema_definitions.get(ref)


### PR DESCRIPTION
Hello, I recently have been starting to use apistar somewhat and came across the TODO related to generically supporting request body media types generically and I made it slightly more generic than it was but admittedly haven't solved issue #669 fully.  This seems to allow me to work around the media type and POST with the "multipart/form-data" encoding so I wanted to submit a PR in case this would be useful to others, but if it would be helpful for me to continue and support more media types as well I'd be happy to do so.