### PR TITLE
Consistently name schema YAML file as schema.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ pip3 install apistar
 
 Let's take a look at some of the functionality the toolkit provides...
 
-We'll start by creating an OpenAPI schema, `schema.yaml`:
+We'll start by creating an OpenAPI schema, `schema.yml`:
 
 ```yaml
 openapi: 3.0.0
@@ -72,7 +72,7 @@ Let's also create a configuration file `apistar.yml`:
 
 ```yaml
 schema:
-  path: schema.yaml
+  path: schema.yml
   format: openapi
 ```
 

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -70,7 +70,7 @@ paths:
           type: string
 """
 
-index_html = apistar.docs(schema, schema_url='/schema.yaml', static_url='/static/')
+index_html = apistar.docs(schema, schema_url='/schema.yml', static_url='/static/')
 ```
 
 If you're serving the documentation dynamically, then you'll also need to make

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ $ pip3 install apistar
 
 Let's take a look at some of the functionality the toolkit provides...
 
-We'll start by creating an OpenAPI schema, `schema.yaml`:
+We'll start by creating an OpenAPI schema, `schema.yml`:
 
 ```yaml
 openapi: 3.0.0


### PR DESCRIPTION
As per the following issues, the documentation mixes between yaml and yml file extensions for the apistar and schema YAML files when the apistar file explicitly needs to have the yml extension. This PR amends the documentation for references to the schema YAML file to have the yml extension.

#630 
#670 
#651 
