### PR TITLE
[Issue-657] Appending path to server url

### DIFF
--- a/apistar/schemas/openapi.py
+++ b/apistar/schemas/openapi.py
@@ -1,7 +1,6 @@
 import re
-from urllib.parse import urljoin
-
 import typesystem
+
 from apistar.document import Document, Field, Link, Section
 from apistar.schemas.jsonschema import JSON_SCHEMA
 
@@ -462,7 +461,7 @@ class OpenAPI:
 
         return Link(
             name=name,
-            url=urljoin(base_url, path),
+            url=(base_url or "") + path,
             method=operation,
             title=title,
             description=description,

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -1,5 +1,4 @@
 import os
-
 import pytest
 
 import apistar
@@ -21,4 +20,7 @@ def test_openapi(filename):
 
     path, extension = os.path.splitext(filename)
     encoding = {".json": "json", ".yaml": "yaml"}[extension]
-    apistar.validate(content, format="openapi", encoding=encoding)
+    document = apistar.validate(content, format="openapi", encoding=encoding)
+    if document.url is not None:
+        for link_info in document.walk_links():
+            assert document.url in link_info.link.url


### PR DESCRIPTION
Fix for the problem stated in issue #657

According  OpenApi standard: "A relative path to an individual endpoint. The field name MUST begin with a forward slash (/). The path is appended (no relative URL resolution) to the expanded URL from the Server Object's url field in order to construct the full URL."

*Added tests to test_openapi