### PR TITLE
upgrade to typesystem 0.3.0

### DIFF
--- a/apistar/schemas/jsonschema.py
+++ b/apistar/schemas/jsonschema.py
@@ -1,6 +1,6 @@
 import typesystem
 
-definitions = typesystem.SchemaDefinitions()
+definitions = typesystem.Definitions()
 
 JSON_SCHEMA = (
     typesystem.Object(

--- a/apistar/schemas/openapi.py
+++ b/apistar/schemas/openapi.py
@@ -15,7 +15,7 @@ RESPONSE_REF = typesystem.Object(
     properties={"$ref": typesystem.String(pattern="^#/components/responses/")}
 )
 
-definitions = typesystem.SchemaDefinitions()
+definitions = typesystem.Definitions()
 
 OPEN_API = typesystem.Object(
     title="OpenAPI",
@@ -367,7 +367,7 @@ class OpenAPI:
         )
 
     def get_schema_definitions(self, data):
-        definitions = typesystem.SchemaDefinitions()
+        definitions = typesystem.Definitions()
         schemas = lookup(data, ["components", "schemas"], {})
         for key, value in schemas.items():
             ref = f"#/components/schemas/{key}"

--- a/apistar/schemas/swagger.py
+++ b/apistar/schemas/swagger.py
@@ -12,7 +12,7 @@ RESPONSE_REF = typesystem.Object(
     properties={"$ref": typesystem.String(pattern="^#/responses/")}
 )
 
-definitions = typesystem.SchemaDefinitions()
+definitions = typesystem.Definitions()
 
 SWAGGER = typesystem.Object(
     title="Swagger",
@@ -357,7 +357,7 @@ class Swagger:
         )
 
     def get_schema_definitions(self, data):
-        definitions = typesystem.SchemaDefinitions()
+        definitions = typesystem.Definitions()
         schemas = lookup(data, ["components", "schemas"], {})
         for key, value in schemas.items():
             ref = f"#/components/schemas/{key}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ click
 jinja2
 requests
 pyyaml
-typesystem>=0.2.0
+typesystem>=0.3.0,<0.4.0
 
 # Testing requirements
 black

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     author_email="tom@tomchristie.com",
     packages=get_packages("apistar"),
     package_data=get_package_data("apistar"),
-    install_requires=["click", "jinja2", "requests", "pyyaml", "typesystem"],
+    install_requires=["click", "jinja2", "requests", "pyyaml", "typesystem>=0.3.0,<0.4.0"],
     python_requires=">=3.6",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     author_email="tom@tomchristie.com",
     packages=get_packages("apistar"),
     package_data=get_package_data("apistar"),
-    install_requires=["click", "jinja2", "requests", "pyyaml", "typesystem>=0.3.0,<0.4.0"],
+    install_requires=["click", "jinja2", "requests", "pyyaml", "typesystem~=0.3"],
     python_requires=">=3.6",
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Right now `apistar` has a loose dependency on `typesystem`.

This PR will support latest release of `typesystem` and also pin dependency.